### PR TITLE
Rename document table to file, update API paths

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -95,7 +95,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Install sqlc
-        run: go install github.com/sqlc-dev/sqlc/cmd/sqlc@latest
+        run: go install github.com/sqlc-dev/sqlc/cmd/sqlc@v1.30.0
 
       - name: Verify sqlc generated code is up to date
         run: |

--- a/db/queries/document.sql
+++ b/db/queries/document.sql
@@ -2,30 +2,30 @@
 SELECT id, "externalID", "mimeType", size, "displayName", "createdBy",
        "temporaryLocation", "storageBucketId", "authorizationId", "tagsetId",
        "createdDate", "updatedDate", version
-FROM document
+FROM file
 WHERE id = $1;
 
 -- name: CreateDocument :one
-INSERT INTO document (id, "externalID", "mimeType", size, "displayName", "createdBy",
+INSERT INTO file (id, "externalID", "mimeType", size, "displayName", "createdBy",
                       "temporaryLocation", "storageBucketId", "authorizationId", "tagsetId",
                       "createdDate", "updatedDate", version)
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, 1)
 RETURNING id;
 
 -- name: UpdateDocumentFile :execrows
-UPDATE document
+UPDATE file
 SET "externalID" = $2, "mimeType" = $3, size = $4, "updatedDate" = $5
 WHERE id = $1;
 
 -- name: UpdateDocumentLocation :execrows
-UPDATE document
+UPDATE file
 SET "storageBucketId" = $2, "temporaryLocation" = $3, "updatedDate" = $4, version = version + 1
 WHERE id = $1 AND version = $5;
 
 -- name: DeleteDocument :one
-DELETE FROM document
+DELETE FROM file
 WHERE id = $1
 RETURNING "externalID", "authorizationId", "tagsetId";
 
 -- name: CountDocumentsByExternalID :one
-SELECT COUNT(*) FROM document WHERE "externalID" = $1;
+SELECT COUNT(*) FROM file WHERE "externalID" = $1;

--- a/db/schema/document.sql
+++ b/db/schema/document.sql
@@ -1,4 +1,4 @@
-CREATE TABLE document (
+CREATE TABLE file (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
     "createdDate" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     "updatedDate" TIMESTAMPTZ NOT NULL DEFAULT NOW(),

--- a/internal/adapter/inbound/http/document_handler_test.go
+++ b/internal/adapter/inbound/http/document_handler_test.go
@@ -53,9 +53,9 @@ func TestDocumentHandler_GetMeta_Found(t *testing.T) {
 	}
 
 	r := chi.NewRouter()
-	r.Get("/internal/document/{id}/meta", h.GetMeta)
+	r.Get("/internal/file/{id}/meta", h.GetMeta)
 
-	req := httptest.NewRequest(http.MethodGet, "/internal/document/"+docID.String()+"/meta", nil)
+	req := httptest.NewRequest(http.MethodGet, "/internal/file/"+docID.String()+"/meta", nil)
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
 
@@ -76,9 +76,9 @@ func TestDocumentHandler_GetMeta_NotFound(t *testing.T) {
 	repo.err = model.ErrDocumentNotFound
 
 	r := chi.NewRouter()
-	r.Get("/internal/document/{id}/meta", h.GetMeta)
+	r.Get("/internal/file/{id}/meta", h.GetMeta)
 
-	req := httptest.NewRequest(http.MethodGet, "/internal/document/"+uuid.New().String()+"/meta", nil)
+	req := httptest.NewRequest(http.MethodGet, "/internal/file/"+uuid.New().String()+"/meta", nil)
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
 
@@ -94,9 +94,9 @@ func TestDocumentHandler_GetContent_Found(t *testing.T) {
 	storage.data = []byte("file content")
 
 	r := chi.NewRouter()
-	r.Get("/internal/document/{id}/content", h.GetContent)
+	r.Get("/internal/file/{id}/content", h.GetContent)
 
-	req := httptest.NewRequest(http.MethodGet, "/internal/document/"+docID.String()+"/content", nil)
+	req := httptest.NewRequest(http.MethodGet, "/internal/file/"+docID.String()+"/content", nil)
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
 
@@ -116,9 +116,9 @@ func TestDocumentHandler_GetContent_NotFound(t *testing.T) {
 	repo.err = model.ErrDocumentNotFound
 
 	r := chi.NewRouter()
-	r.Get("/internal/document/{id}/content", h.GetContent)
+	r.Get("/internal/file/{id}/content", h.GetContent)
 
-	req := httptest.NewRequest(http.MethodGet, "/internal/document/"+uuid.New().String()+"/content", nil)
+	req := httptest.NewRequest(http.MethodGet, "/internal/file/"+uuid.New().String()+"/content", nil)
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
 
@@ -133,9 +133,9 @@ func TestDocumentHandler_GetContent_FileMissing(t *testing.T) {
 	storage.err = os.ErrNotExist
 
 	r := chi.NewRouter()
-	r.Get("/internal/document/{id}/content", h.GetContent)
+	r.Get("/internal/file/{id}/content", h.GetContent)
 
-	req := httptest.NewRequest(http.MethodGet, "/internal/document/"+uuid.New().String()+"/content", nil)
+	req := httptest.NewRequest(http.MethodGet, "/internal/file/"+uuid.New().String()+"/content", nil)
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
 
@@ -157,9 +157,9 @@ func TestDocumentHandler_Create_Success(t *testing.T) {
 	_ = writer.Close()
 
 	r := chi.NewRouter()
-	r.Post("/internal/document", h.Create)
+	r.Post("/internal/file", h.Create)
 
-	req := httptest.NewRequest(http.MethodPost, "/internal/document", &body)
+	req := httptest.NewRequest(http.MethodPost, "/internal/file", &body)
 	req.Header.Set("Content-Type", writer.FormDataContentType())
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
@@ -194,9 +194,9 @@ func TestDocumentHandler_Create_AllFields(t *testing.T) {
 	_ = writer.Close()
 
 	r := chi.NewRouter()
-	r.Post("/internal/document", h.Create)
+	r.Post("/internal/file", h.Create)
 
-	req := httptest.NewRequest(http.MethodPost, "/internal/document", &body)
+	req := httptest.NewRequest(http.MethodPost, "/internal/file", &body)
 	req.Header.Set("Content-Type", writer.FormDataContentType())
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
@@ -219,9 +219,9 @@ func TestDocumentHandler_Create_InvalidAuthorizationId(t *testing.T) {
 	_ = writer.Close()
 
 	r := chi.NewRouter()
-	r.Post("/internal/document", h.Create)
+	r.Post("/internal/file", h.Create)
 
-	req := httptest.NewRequest(http.MethodPost, "/internal/document", &body)
+	req := httptest.NewRequest(http.MethodPost, "/internal/file", &body)
 	req.Header.Set("Content-Type", writer.FormDataContentType())
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
@@ -245,9 +245,9 @@ func TestDocumentHandler_Create_InvalidTagsetId(t *testing.T) {
 	_ = writer.Close()
 
 	r := chi.NewRouter()
-	r.Post("/internal/document", h.Create)
+	r.Post("/internal/file", h.Create)
 
-	req := httptest.NewRequest(http.MethodPost, "/internal/document", &body)
+	req := httptest.NewRequest(http.MethodPost, "/internal/file", &body)
 	req.Header.Set("Content-Type", writer.FormDataContentType())
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
@@ -271,9 +271,9 @@ func TestDocumentHandler_Create_InvalidCreatedBy(t *testing.T) {
 	_ = writer.Close()
 
 	r := chi.NewRouter()
-	r.Post("/internal/document", h.Create)
+	r.Post("/internal/file", h.Create)
 
-	req := httptest.NewRequest(http.MethodPost, "/internal/document", &body)
+	req := httptest.NewRequest(http.MethodPost, "/internal/file", &body)
 	req.Header.Set("Content-Type", writer.FormDataContentType())
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
@@ -297,9 +297,9 @@ func TestDocumentHandler_Create_ServiceError(t *testing.T) {
 	_ = writer.Close()
 
 	r := chi.NewRouter()
-	r.Post("/internal/document", h.Create)
+	r.Post("/internal/file", h.Create)
 
-	req := httptest.NewRequest(http.MethodPost, "/internal/document", &body)
+	req := httptest.NewRequest(http.MethodPost, "/internal/file", &body)
 	req.Header.Set("Content-Type", writer.FormDataContentType())
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
@@ -316,10 +316,10 @@ func TestDocumentHandler_Patch_WithBucketId(t *testing.T) {
 	repo.doc = model.Document{ID: docID, StorageBucketID: uuid.New(), TemporaryLocation: true}
 
 	r := chi.NewRouter()
-	r.Patch("/internal/document/{id}", h.Update)
+	r.Patch("/internal/file/{id}", h.Update)
 
 	body := `{"storageBucketId": "` + newBucket.String() + `", "temporaryLocation": false}`
-	req := httptest.NewRequest(http.MethodPatch, "/internal/document/"+docID.String(), strings.NewReader(body))
+	req := httptest.NewRequest(http.MethodPatch, "/internal/file/"+docID.String(), strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
@@ -340,9 +340,9 @@ func TestDocumentHandler_Delete_WithTagset(t *testing.T) {
 	repo.count = 1
 
 	r := chi.NewRouter()
-	r.Delete("/internal/document/{id}", h.Delete)
+	r.Delete("/internal/file/{id}", h.Delete)
 
-	req := httptest.NewRequest(http.MethodDelete, "/internal/document/"+docID.String(), nil)
+	req := httptest.NewRequest(http.MethodDelete, "/internal/file/"+docID.String(), nil)
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
 
@@ -366,9 +366,9 @@ func TestDocumentHandler_Delete_Success(t *testing.T) {
 	repo.count = 1
 
 	r := chi.NewRouter()
-	r.Delete("/internal/document/{id}", h.Delete)
+	r.Delete("/internal/file/{id}", h.Delete)
 
-	req := httptest.NewRequest(http.MethodDelete, "/internal/document/"+docID.String(), nil)
+	req := httptest.NewRequest(http.MethodDelete, "/internal/file/"+docID.String(), nil)
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
 
@@ -383,10 +383,10 @@ func TestDocumentHandler_Patch_Success(t *testing.T) {
 	repo.doc = model.Document{ID: docID, StorageBucketID: uuid.New(), TemporaryLocation: true}
 
 	r := chi.NewRouter()
-	r.Patch("/internal/document/{id}", h.Update)
+	r.Patch("/internal/file/{id}", h.Update)
 
 	body := `{"temporaryLocation": false}`
-	req := httptest.NewRequest(http.MethodPatch, "/internal/document/"+docID.String(), strings.NewReader(body))
+	req := httptest.NewRequest(http.MethodPatch, "/internal/file/"+docID.String(), strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
@@ -402,9 +402,9 @@ func TestDocumentHandler_ReplaceContent_Success(t *testing.T) {
 	repo.doc = model.Document{ID: docID, ExternalID: "old"}
 
 	r := chi.NewRouter()
-	r.Put("/internal/document/{id}/content", h.ReplaceContent)
+	r.Put("/internal/file/{id}/content", h.ReplaceContent)
 
-	req := httptest.NewRequest(http.MethodPut, "/internal/document/"+docID.String()+"/content", strings.NewReader("new content"))
+	req := httptest.NewRequest(http.MethodPut, "/internal/file/"+docID.String()+"/content", strings.NewReader("new content"))
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
 
@@ -419,10 +419,10 @@ func TestDocumentHandler_Create_MissingFile(t *testing.T) {
 	h, _, _ := newDocHandler()
 
 	r := chi.NewRouter()
-	r.Post("/internal/document", h.Create)
+	r.Post("/internal/file", h.Create)
 
 	// Empty body, no multipart
-	req := httptest.NewRequest(http.MethodPost, "/internal/document", strings.NewReader(""))
+	req := httptest.NewRequest(http.MethodPost, "/internal/file", strings.NewReader(""))
 	req.Header.Set("Content-Type", "multipart/form-data; boundary=xxx")
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
@@ -445,9 +445,9 @@ func TestDocumentHandler_Create_MissingDisplayName(t *testing.T) {
 	_ = writer.Close()
 
 	r := chi.NewRouter()
-	r.Post("/internal/document", h.Create)
+	r.Post("/internal/file", h.Create)
 
-	req := httptest.NewRequest(http.MethodPost, "/internal/document", &body)
+	req := httptest.NewRequest(http.MethodPost, "/internal/file", &body)
 	req.Header.Set("Content-Type", writer.FormDataContentType())
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
@@ -470,9 +470,9 @@ func TestDocumentHandler_Create_InvalidStorageBucketId(t *testing.T) {
 	_ = writer.Close()
 
 	r := chi.NewRouter()
-	r.Post("/internal/document", h.Create)
+	r.Post("/internal/file", h.Create)
 
-	req := httptest.NewRequest(http.MethodPost, "/internal/document", &body)
+	req := httptest.NewRequest(http.MethodPost, "/internal/file", &body)
 	req.Header.Set("Content-Type", writer.FormDataContentType())
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
@@ -496,9 +496,9 @@ func TestDocumentHandler_Create_TooLarge(t *testing.T) {
 	_ = writer.Close()
 
 	r := chi.NewRouter()
-	r.Post("/internal/document", h.Create)
+	r.Post("/internal/file", h.Create)
 
-	req := httptest.NewRequest(http.MethodPost, "/internal/document", &body)
+	req := httptest.NewRequest(http.MethodPost, "/internal/file", &body)
 	req.Header.Set("Content-Type", writer.FormDataContentType())
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
@@ -522,9 +522,9 @@ func TestDocumentHandler_Create_UnsupportedMIME(t *testing.T) {
 	_ = writer.Close()
 
 	r := chi.NewRouter()
-	r.Post("/internal/document", h.Create)
+	r.Post("/internal/file", h.Create)
 
-	req := httptest.NewRequest(http.MethodPost, "/internal/document", &body)
+	req := httptest.NewRequest(http.MethodPost, "/internal/file", &body)
 	req.Header.Set("Content-Type", writer.FormDataContentType())
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
@@ -541,9 +541,9 @@ func TestDocumentHandler_Delete_NotFound(t *testing.T) {
 	repo.deleteErr = model.ErrDocumentNotFound
 
 	r := chi.NewRouter()
-	r.Delete("/internal/document/{id}", h.Delete)
+	r.Delete("/internal/file/{id}", h.Delete)
 
-	req := httptest.NewRequest(http.MethodDelete, "/internal/document/"+uuid.New().String(), nil)
+	req := httptest.NewRequest(http.MethodDelete, "/internal/file/"+uuid.New().String(), nil)
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
 
@@ -556,9 +556,9 @@ func TestDocumentHandler_Delete_InvalidID(t *testing.T) {
 	h, _, _ := newDocHandler()
 
 	r := chi.NewRouter()
-	r.Delete("/internal/document/{id}", h.Delete)
+	r.Delete("/internal/file/{id}", h.Delete)
 
-	req := httptest.NewRequest(http.MethodDelete, "/internal/document/not-a-uuid", nil)
+	req := httptest.NewRequest(http.MethodDelete, "/internal/file/not-a-uuid", nil)
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
 
@@ -574,10 +574,10 @@ func TestDocumentHandler_Patch_NotFound(t *testing.T) {
 	repo.err = model.ErrDocumentNotFound
 
 	r := chi.NewRouter()
-	r.Patch("/internal/document/{id}", h.Update)
+	r.Patch("/internal/file/{id}", h.Update)
 
 	body := `{"temporaryLocation": false}`
-	req := httptest.NewRequest(http.MethodPatch, "/internal/document/"+uuid.New().String(), strings.NewReader(body))
+	req := httptest.NewRequest(http.MethodPatch, "/internal/file/"+uuid.New().String(), strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
@@ -591,9 +591,9 @@ func TestDocumentHandler_Patch_InvalidJSON(t *testing.T) {
 	h, _, _ := newDocHandler()
 
 	r := chi.NewRouter()
-	r.Patch("/internal/document/{id}", h.Update)
+	r.Patch("/internal/file/{id}", h.Update)
 
-	req := httptest.NewRequest(http.MethodPatch, "/internal/document/"+uuid.New().String(), strings.NewReader("{invalid"))
+	req := httptest.NewRequest(http.MethodPatch, "/internal/file/"+uuid.New().String(), strings.NewReader("{invalid"))
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
@@ -607,9 +607,9 @@ func TestDocumentHandler_Patch_EmptyBody(t *testing.T) {
 	h, _, _ := newDocHandler()
 
 	r := chi.NewRouter()
-	r.Patch("/internal/document/{id}", h.Update)
+	r.Patch("/internal/file/{id}", h.Update)
 
-	req := httptest.NewRequest(http.MethodPatch, "/internal/document/"+uuid.New().String(), strings.NewReader("{}"))
+	req := httptest.NewRequest(http.MethodPatch, "/internal/file/"+uuid.New().String(), strings.NewReader("{}"))
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
@@ -624,10 +624,10 @@ func TestDocumentHandler_Patch_InvalidBucketId(t *testing.T) {
 	repo.doc = model.Document{ID: uuid.New(), StorageBucketID: uuid.New()}
 
 	r := chi.NewRouter()
-	r.Patch("/internal/document/{id}", h.Update)
+	r.Patch("/internal/file/{id}", h.Update)
 
 	body := `{"storageBucketId": "not-a-uuid"}`
-	req := httptest.NewRequest(http.MethodPatch, "/internal/document/"+uuid.New().String(), strings.NewReader(body))
+	req := httptest.NewRequest(http.MethodPatch, "/internal/file/"+uuid.New().String(), strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
@@ -643,9 +643,9 @@ func TestDocumentHandler_GetMeta_InvalidID(t *testing.T) {
 	h, _, _ := newDocHandler()
 
 	r := chi.NewRouter()
-	r.Get("/internal/document/{id}/meta", h.GetMeta)
+	r.Get("/internal/file/{id}/meta", h.GetMeta)
 
-	req := httptest.NewRequest(http.MethodGet, "/internal/document/not-a-uuid/meta", nil)
+	req := httptest.NewRequest(http.MethodGet, "/internal/file/not-a-uuid/meta", nil)
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
 
@@ -658,9 +658,9 @@ func TestDocumentHandler_GetContent_InvalidID(t *testing.T) {
 	h, _, _ := newDocHandler()
 
 	r := chi.NewRouter()
-	r.Get("/internal/document/{id}/content", h.GetContent)
+	r.Get("/internal/file/{id}/content", h.GetContent)
 
-	req := httptest.NewRequest(http.MethodGet, "/internal/document/not-a-uuid/content", nil)
+	req := httptest.NewRequest(http.MethodGet, "/internal/file/not-a-uuid/content", nil)
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
 
@@ -673,9 +673,9 @@ func TestDocumentHandler_ReplaceContent_InvalidID(t *testing.T) {
 	h, _, _ := newDocHandler()
 
 	r := chi.NewRouter()
-	r.Put("/internal/document/{id}/content", h.ReplaceContent)
+	r.Put("/internal/file/{id}/content", h.ReplaceContent)
 
-	req := httptest.NewRequest(http.MethodPut, "/internal/document/not-a-uuid/content", strings.NewReader("content"))
+	req := httptest.NewRequest(http.MethodPut, "/internal/file/not-a-uuid/content", strings.NewReader("content"))
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
 
@@ -731,9 +731,9 @@ func TestDocumentHandler_ReplaceContent_NotFound(t *testing.T) {
 	repo.err = model.ErrDocumentNotFound
 
 	r := chi.NewRouter()
-	r.Put("/internal/document/{id}/content", h.ReplaceContent)
+	r.Put("/internal/file/{id}/content", h.ReplaceContent)
 
-	req := httptest.NewRequest(http.MethodPut, "/internal/document/"+uuid.New().String()+"/content", strings.NewReader("content"))
+	req := httptest.NewRequest(http.MethodPut, "/internal/file/"+uuid.New().String()+"/content", strings.NewReader("content"))
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
 
@@ -748,9 +748,9 @@ func TestDocumentHandler_ReplaceContent_InternalError(t *testing.T) {
 	storage.saveErr = errors.New("disk full")
 
 	r := chi.NewRouter()
-	r.Put("/internal/document/{id}/content", h.ReplaceContent)
+	r.Put("/internal/file/{id}/content", h.ReplaceContent)
 
-	req := httptest.NewRequest(http.MethodPut, "/internal/document/"+uuid.New().String()+"/content", strings.NewReader("content"))
+	req := httptest.NewRequest(http.MethodPut, "/internal/file/"+uuid.New().String()+"/content", strings.NewReader("content"))
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
 
@@ -765,9 +765,9 @@ func TestDocumentHandler_Delete_InternalError(t *testing.T) {
 	repo.deleteErr = errors.New("db error")
 
 	r := chi.NewRouter()
-	r.Delete("/internal/document/{id}", h.Delete)
+	r.Delete("/internal/file/{id}", h.Delete)
 
-	req := httptest.NewRequest(http.MethodDelete, "/internal/document/"+uuid.New().String(), nil)
+	req := httptest.NewRequest(http.MethodDelete, "/internal/file/"+uuid.New().String(), nil)
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
 
@@ -782,10 +782,10 @@ func TestDocumentHandler_Patch_UpdateError(t *testing.T) {
 	repo.updateErr = errors.New("db error")
 
 	r := chi.NewRouter()
-	r.Patch("/internal/document/{id}", h.Update)
+	r.Patch("/internal/file/{id}", h.Update)
 
 	body := `{"temporaryLocation": false}`
-	req := httptest.NewRequest(http.MethodPatch, "/internal/document/"+uuid.New().String(), strings.NewReader(body))
+	req := httptest.NewRequest(http.MethodPatch, "/internal/file/"+uuid.New().String(), strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
@@ -801,10 +801,10 @@ func TestDocumentHandler_Patch_VersionConflict(t *testing.T) {
 	repo.updateErr = model.ErrDocumentNotFound // 0 rows = version mismatch
 
 	r := chi.NewRouter()
-	r.Patch("/internal/document/{id}", h.Update)
+	r.Patch("/internal/file/{id}", h.Update)
 
 	body := `{"temporaryLocation": false}`
-	req := httptest.NewRequest(http.MethodPatch, "/internal/document/"+uuid.New().String(), strings.NewReader(body))
+	req := httptest.NewRequest(http.MethodPatch, "/internal/file/"+uuid.New().String(), strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
@@ -819,9 +819,9 @@ func TestDocumentHandler_GetMeta_InternalError(t *testing.T) {
 	repo.err = errors.New("db connection lost")
 
 	r := chi.NewRouter()
-	r.Get("/internal/document/{id}/meta", h.GetMeta)
+	r.Get("/internal/file/{id}/meta", h.GetMeta)
 
-	req := httptest.NewRequest(http.MethodGet, "/internal/document/"+uuid.New().String()+"/meta", nil)
+	req := httptest.NewRequest(http.MethodGet, "/internal/file/"+uuid.New().String()+"/meta", nil)
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
 
@@ -835,9 +835,9 @@ func TestDocumentHandler_GetContent_InternalError(t *testing.T) {
 	repo.err = errors.New("db connection lost")
 
 	r := chi.NewRouter()
-	r.Get("/internal/document/{id}/content", h.GetContent)
+	r.Get("/internal/file/{id}/content", h.GetContent)
 
-	req := httptest.NewRequest(http.MethodGet, "/internal/document/"+uuid.New().String()+"/content", nil)
+	req := httptest.NewRequest(http.MethodGet, "/internal/file/"+uuid.New().String()+"/content", nil)
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
 

--- a/internal/adapter/inbound/http/router.go
+++ b/internal/adapter/inbound/http/router.go
@@ -30,8 +30,8 @@ func NewRouter(deps Deps) *chi.Mux {
 	// Public endpoints (Oathkeeper strips /api/private, arrives as /rest/storage/...)
 	r.Route("/rest/storage", func(r chi.Router) {
 		r.Use(JWTExtractor)
-		r.Get("/file/{id}", deps.PublicHandler.ServeDocument)
 		r.Get("/document/{id}", deps.PublicHandler.ServeDocument) // backward compat alias
+		r.Get("/file/{id}", deps.PublicHandler.ServeDocument)
 	})
 
 	// Internal endpoints (no auth)

--- a/internal/adapter/inbound/http/router.go
+++ b/internal/adapter/inbound/http/router.go
@@ -30,17 +30,18 @@ func NewRouter(deps Deps) *chi.Mux {
 	// Public endpoints (Oathkeeper strips /api/private, arrives as /rest/storage/...)
 	r.Route("/rest/storage", func(r chi.Router) {
 		r.Use(JWTExtractor)
-		r.Get("/document/{id}", deps.PublicHandler.ServeDocument)
+		r.Get("/file/{id}", deps.PublicHandler.ServeDocument)
+		r.Get("/document/{id}", deps.PublicHandler.ServeDocument) // backward compat alias
 	})
 
 	// Internal endpoints (no auth)
 	r.Route("/internal", func(r chi.Router) {
-		r.Post("/document", deps.DocumentHandler.Create)
-		r.Get("/document/{id}/meta", deps.DocumentHandler.GetMeta)
-		r.Get("/document/{id}/content", deps.DocumentHandler.GetContent)
-		r.Put("/document/{id}/content", deps.DocumentHandler.ReplaceContent)
-		r.Delete("/document/{id}", deps.DocumentHandler.Delete)
-		r.Patch("/document/{id}", deps.DocumentHandler.Update)
+		r.Post("/file", deps.DocumentHandler.Create)
+		r.Get("/file/{id}/meta", deps.DocumentHandler.GetMeta)
+		r.Get("/file/{id}/content", deps.DocumentHandler.GetContent)
+		r.Put("/file/{id}/content", deps.DocumentHandler.ReplaceContent)
+		r.Delete("/file/{id}", deps.DocumentHandler.Delete)
+		r.Patch("/file/{id}", deps.DocumentHandler.Update)
 
 		// Debug/metrics
 		r.Handle("/debug/vars", expvar.Handler())

--- a/internal/adapter/inbound/http/router_test.go
+++ b/internal/adapter/inbound/http/router_test.go
@@ -87,75 +87,75 @@ func TestRouter_PublicDocumentRequiresJWT(t *testing.T) {
 func TestRouter_InternalGetMeta(t *testing.T) {
 	r := testRouter()
 
-	req := httptest.NewRequest(http.MethodGet, "/internal/document/"+uuid.New().String()+"/meta", nil)
+	req := httptest.NewRequest(http.MethodGet, "/internal/file/"+uuid.New().String()+"/meta", nil)
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
 
 	// Should not be 404 (route exists) — may be 200 or 500 depending on mock
 	if rr.Code == http.StatusNotFound && !strings.Contains(rr.Body.String(), "document not found") {
-		t.Errorf("GET /internal/document/:id/meta returned route-level 404")
+		t.Errorf("GET /internal/file/:id/meta returned route-level 404")
 	}
 }
 
 func TestRouter_InternalGetContent(t *testing.T) {
 	r := testRouter()
 
-	req := httptest.NewRequest(http.MethodGet, "/internal/document/"+uuid.New().String()+"/content", nil)
+	req := httptest.NewRequest(http.MethodGet, "/internal/file/"+uuid.New().String()+"/content", nil)
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
 
 	if rr.Code == http.StatusMethodNotAllowed {
-		t.Error("route not registered for GET /internal/document/:id/content")
+		t.Error("route not registered for GET /internal/file/:id/content")
 	}
 }
 
 func TestRouter_InternalCreateDocument(t *testing.T) {
 	r := testRouter()
 
-	req := httptest.NewRequest(http.MethodPost, "/internal/document", strings.NewReader(""))
+	req := httptest.NewRequest(http.MethodPost, "/internal/file", strings.NewReader(""))
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
 
 	// 400 (bad request) is fine — route is registered, handler rejects invalid input
 	if rr.Code == http.StatusNotFound || rr.Code == http.StatusMethodNotAllowed {
-		t.Errorf("POST /internal/document = %d, route not registered", rr.Code)
+		t.Errorf("POST /internal/file = %d, route not registered", rr.Code)
 	}
 }
 
 func TestRouter_InternalDeleteDocument(t *testing.T) {
 	r := testRouter()
 
-	req := httptest.NewRequest(http.MethodDelete, "/internal/document/"+uuid.New().String(), nil)
+	req := httptest.NewRequest(http.MethodDelete, "/internal/file/"+uuid.New().String(), nil)
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
 
 	if rr.Code == http.StatusMethodNotAllowed {
-		t.Error("route not registered for DELETE /internal/document/:id")
+		t.Error("route not registered for DELETE /internal/file/:id")
 	}
 }
 
 func TestRouter_InternalPatchDocument(t *testing.T) {
 	r := testRouter()
 
-	req := httptest.NewRequest(http.MethodPatch, "/internal/document/"+uuid.New().String(), strings.NewReader("{}"))
+	req := httptest.NewRequest(http.MethodPatch, "/internal/file/"+uuid.New().String(), strings.NewReader("{}"))
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
 
 	if rr.Code == http.StatusMethodNotAllowed {
-		t.Error("route not registered for PATCH /internal/document/:id")
+		t.Error("route not registered for PATCH /internal/file/:id")
 	}
 }
 
 func TestRouter_InternalPutContent(t *testing.T) {
 	r := testRouter()
 
-	req := httptest.NewRequest(http.MethodPut, "/internal/document/"+uuid.New().String()+"/content", strings.NewReader("data"))
+	req := httptest.NewRequest(http.MethodPut, "/internal/file/"+uuid.New().String()+"/content", strings.NewReader("data"))
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
 
 	if rr.Code == http.StatusMethodNotAllowed {
-		t.Error("route not registered for PUT /internal/document/:id/content")
+		t.Error("route not registered for PUT /internal/file/:id/content")
 	}
 }
 
@@ -163,7 +163,7 @@ func TestRouter_InternalNoAuth(t *testing.T) {
 	r := testRouter()
 
 	// Internal endpoints should work without Authorization header
-	req := httptest.NewRequest(http.MethodGet, "/internal/document/"+uuid.New().String()+"/meta", nil)
+	req := httptest.NewRequest(http.MethodGet, "/internal/file/"+uuid.New().String()+"/meta", nil)
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
 

--- a/internal/adapter/inbound/http/router_test.go
+++ b/internal/adapter/inbound/http/router_test.go
@@ -91,8 +91,8 @@ func TestRouter_InternalGetMeta(t *testing.T) {
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
 
-	// Should not be 404 (route exists) — may be 200 or 500 depending on mock
-	if rr.Code == http.StatusNotFound && !strings.Contains(rr.Body.String(), "document not found") {
+	// Should not be route-level 404 (route exists) — handler-level failures are acceptable
+	if rr.Code == http.StatusNotFound {
 		t.Errorf("GET /internal/file/:id/meta returned route-level 404")
 	}
 }

--- a/internal/adapter/outbound/alkemiodb/adapter_mock_test.go
+++ b/internal/adapter/outbound/alkemiodb/adapter_mock_test.go
@@ -31,7 +31,7 @@ func TestMock_GetByID_Found(t *testing.T) {
 	bucketID := uuid.New()
 	now := time.Now()
 
-	mock.ExpectQuery("SELECT .+ FROM document WHERE id").
+	mock.ExpectQuery("SELECT .+ FROM file WHERE id").
 		WithArgs(pgtype.UUID{Bytes: docID, Valid: true}).
 		WillReturnRows(mock.NewRows(columns()).AddRow(
 			pgtype.UUID{Bytes: docID, Valid: true},
@@ -75,7 +75,7 @@ func TestMock_GetByID_NotFound(t *testing.T) {
 	}
 	defer mock.Close()
 
-	mock.ExpectQuery("SELECT .+ FROM document WHERE id").
+	mock.ExpectQuery("SELECT .+ FROM file WHERE id").
 		WithArgs(pgxmock.AnyArg()).
 		WillReturnRows(mock.NewRows(columns()))
 
@@ -98,7 +98,7 @@ func TestMock_Create_Success(t *testing.T) {
 
 	docID := uuid.New()
 
-	mock.ExpectQuery("INSERT INTO document").
+	mock.ExpectQuery("INSERT INTO file").
 		WithArgs(
 			pgxmock.AnyArg(), // id
 			pgxmock.AnyArg(), // externalID
@@ -146,7 +146,7 @@ func TestMock_UpdateFile_Success(t *testing.T) {
 	}
 	defer mock.Close()
 
-	mock.ExpectExec("UPDATE document SET").
+	mock.ExpectExec("UPDATE file SET").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
 
@@ -167,7 +167,7 @@ func TestMock_UpdateFile_NotFound(t *testing.T) {
 	}
 	defer mock.Close()
 
-	mock.ExpectExec("UPDATE document SET").
+	mock.ExpectExec("UPDATE file SET").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 0))
 
@@ -188,7 +188,7 @@ func TestMock_Delete_Success(t *testing.T) {
 	authID := uuid.New()
 	tagsetID := uuid.New()
 
-	mock.ExpectQuery("DELETE FROM document WHERE id").
+	mock.ExpectQuery("DELETE FROM file WHERE id").
 		WithArgs(pgxmock.AnyArg()).
 		WillReturnRows(mock.NewRows([]string{"externalID", "authorizationId", "tagsetId"}).
 			AddRow("abc123", pgtype.UUID{Bytes: authID, Valid: true}, pgtype.UUID{Bytes: tagsetID, Valid: true}))
@@ -213,7 +213,7 @@ func TestMock_Delete_NotFound(t *testing.T) {
 	}
 	defer mock.Close()
 
-	mock.ExpectQuery("DELETE FROM document WHERE id").
+	mock.ExpectQuery("DELETE FROM file WHERE id").
 		WithArgs(pgxmock.AnyArg()).
 		WillReturnRows(mock.NewRows([]string{"externalID", "authorizationId", "tagsetId"}))
 
@@ -252,7 +252,7 @@ func TestMock_UpdateLocation_Success(t *testing.T) {
 	}
 	defer mock.Close()
 
-	mock.ExpectExec("UPDATE document SET").
+	mock.ExpectExec("UPDATE file SET").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
 
@@ -270,7 +270,7 @@ func TestMock_UpdateLocation_NotFound(t *testing.T) {
 	}
 	defer mock.Close()
 
-	mock.ExpectExec("UPDATE document SET").
+	mock.ExpectExec("UPDATE file SET").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 0))
 
@@ -288,7 +288,7 @@ func TestMock_GetByID_DBError(t *testing.T) {
 	}
 	defer mock.Close()
 
-	mock.ExpectQuery("SELECT .+ FROM document WHERE id").
+	mock.ExpectQuery("SELECT .+ FROM file WHERE id").
 		WithArgs(pgxmock.AnyArg()).
 		WillReturnError(errors.New("connection reset"))
 
@@ -309,7 +309,7 @@ func TestMock_UpdateFile_DBError(t *testing.T) {
 	}
 	defer mock.Close()
 
-	mock.ExpectExec("UPDATE document SET").
+	mock.ExpectExec("UPDATE file SET").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnError(errors.New("connection reset"))
 
@@ -327,7 +327,7 @@ func TestMock_UpdateLocation_DBError(t *testing.T) {
 	}
 	defer mock.Close()
 
-	mock.ExpectExec("UPDATE document SET").
+	mock.ExpectExec("UPDATE file SET").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnError(errors.New("connection reset"))
 
@@ -345,7 +345,7 @@ func TestMock_Delete_DBError(t *testing.T) {
 	}
 	defer mock.Close()
 
-	mock.ExpectQuery("DELETE FROM document WHERE id").
+	mock.ExpectQuery("DELETE FROM file WHERE id").
 		WithArgs(pgxmock.AnyArg()).
 		WillReturnError(errors.New("connection reset"))
 
@@ -384,7 +384,7 @@ func TestMock_Create_DBError(t *testing.T) {
 	}
 	defer mock.Close()
 
-	mock.ExpectQuery("INSERT INTO document").
+	mock.ExpectQuery("INSERT INTO file").
 		WithArgs(
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),

--- a/internal/adapter/outbound/alkemiodb/queries/document.sql.go
+++ b/internal/adapter/outbound/alkemiodb/queries/document.sql.go
@@ -12,7 +12,7 @@ import (
 )
 
 const countDocumentsByExternalID = `-- name: CountDocumentsByExternalID :one
-SELECT COUNT(*) FROM document WHERE "externalID" = $1
+SELECT COUNT(*) FROM file WHERE "externalID" = $1
 `
 
 func (q *Queries) CountDocumentsByExternalID(ctx context.Context, externalid string) (int64, error) {
@@ -23,7 +23,7 @@ func (q *Queries) CountDocumentsByExternalID(ctx context.Context, externalid str
 }
 
 const createDocument = `-- name: CreateDocument :one
-INSERT INTO document (id, "externalID", "mimeType", size, "displayName", "createdBy",
+INSERT INTO file (id, "externalID", "mimeType", size, "displayName", "createdBy",
                       "temporaryLocation", "storageBucketId", "authorizationId", "tagsetId",
                       "createdDate", "updatedDate", version)
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, 1)
@@ -66,7 +66,7 @@ func (q *Queries) CreateDocument(ctx context.Context, arg CreateDocumentParams) 
 }
 
 const deleteDocument = `-- name: DeleteDocument :one
-DELETE FROM document
+DELETE FROM file
 WHERE id = $1
 RETURNING "externalID", "authorizationId", "tagsetId"
 `
@@ -88,7 +88,7 @@ const getDocumentByID = `-- name: GetDocumentByID :one
 SELECT id, "externalID", "mimeType", size, "displayName", "createdBy",
        "temporaryLocation", "storageBucketId", "authorizationId", "tagsetId",
        "createdDate", "updatedDate", version
-FROM document
+FROM file
 WHERE id = $1
 `
 
@@ -130,7 +130,7 @@ func (q *Queries) GetDocumentByID(ctx context.Context, id pgtype.UUID) (GetDocum
 }
 
 const updateDocumentFile = `-- name: UpdateDocumentFile :execrows
-UPDATE document
+UPDATE file
 SET "externalID" = $2, "mimeType" = $3, size = $4, "updatedDate" = $5
 WHERE id = $1
 `
@@ -158,7 +158,7 @@ func (q *Queries) UpdateDocumentFile(ctx context.Context, arg UpdateDocumentFile
 }
 
 const updateDocumentLocation = `-- name: UpdateDocumentLocation :execrows
-UPDATE document
+UPDATE file
 SET "storageBucketId" = $2, "temporaryLocation" = $3, "updatedDate" = $4, version = version + 1
 WHERE id = $1 AND version = $5
 `

--- a/internal/adapter/outbound/alkemiodb/queries/models.go
+++ b/internal/adapter/outbound/alkemiodb/queries/models.go
@@ -8,7 +8,7 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
-type Document struct {
+type File struct {
 	ID                pgtype.UUID        `json:"id"`
 	CreatedDate       pgtype.Timestamptz `json:"createdDate"`
 	UpdatedDate       pgtype.Timestamptz `json:"updatedDate"`

--- a/manifests/25-file-service-deployment-dev.yaml
+++ b/manifests/25-file-service-deployment-dev.yaml
@@ -4,6 +4,7 @@ metadata:
   name: alkemio-file-service-deployment
   labels:
     app: alkemio-file-service
+    k8s-app: alkemio-file-service
 spec:
   replicas: 1
   selector:
@@ -14,57 +15,84 @@ spec:
       labels:
         app: alkemio-file-service
     spec:
-      securityContext:
-        fsGroup: 65532
-        runAsNonRoot: true
       containers:
         - name: alkemio-file-service
-          image: alkemio/file-service-go:v0.1.0  # Pin to release tag; CI updates via kubectl set image
-          securityContext:
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop:
-                - ALL
+          image: alkemio/file-service-go:v0.0.4
+          imagePullPolicy: Always
           ports:
-            - containerPort: 4003
+            - name: http
+              containerPort: 4003
           env:
-            - name: PORT
-              value: "4003"
+            - name: ALKEMIO_DATABASE_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: alkemio-config
+                  key: DATABASE_HOST
+            - name: ALKEMIO_DATABASE_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: alkemio-config
+                  key: DATABASE_PORT
+            - name: ALKEMIO_DATABASE_USERNAME
+              valueFrom:
+                configMapKeyRef:
+                  name: alkemio-config
+                  key: POSTGRES_USER
+            - name: ALKEMIO_DATABASE_PASSWORD
+              valueFrom:
+                configMapKeyRef:
+                  name: alkemio-config
+                  key: POSTGRES_PASSWORD
+            - name: ALKEMIO_DATABASE_NAME
+              value: "alkemio"
+            - name: AUTH_SERVICE_URL
+              value: "http://alkemio-authorization-evaluation-service:6060"
             - name: LOCAL_STORAGE_PATH
               value: "/storage"
             - name: STORAGE_TYPE
               value: "local"
-            - name: DOCUMENT_MAX_AGE
-              value: "86400"
-          envFrom:
-            - configMapRef:
-                name: alkemio-config
-            - secretRef:
-                name: alkemio-secrets
+            - name: LOG_LEVEL
+              value: "info"
           volumeMounts:
             - name: file-storage
               mountPath: /storage
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 4003
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            failureThreshold: 3
           livenessProbe:
             httpGet:
               path: /health
               port: 4003
             initialDelaySeconds: 5
             periodSeconds: 10
-          readinessProbe:
-            httpGet:
-              path: /health
-              port: 4003
-            initialDelaySeconds: 3
-            periodSeconds: 5
+            failureThreshold: 3
           resources:
             requests:
-              memory: "128Mi"
-              cpu: "100m"
+              cpu: 200m
+              memory: 256Mi
             limits:
-              memory: "512Mi"
-              cpu: "500m"
+              cpu: 500m
+              memory: 512Mi
       volumes:
         - name: file-storage
           persistentVolumeClaim:
-            claimName: file-storage-pvc2
+            claimName: file-storage-pvc
+      affinity:
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: alkemio-server
+                topologyKey: kubernetes.io/hostname
+            - weight: 50
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: alkemio-authorization-evaluation-service
+                topologyKey: kubernetes.io/hostname

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -127,7 +127,7 @@ info:
   version: 1.0.0
 openapi: 3.1.1
 paths:
-  /internal/document:
+  /internal/file:
     post:
       operationId: DocumentHandler.Create
       parameters:
@@ -170,7 +170,7 @@ paths:
           description: Internal Server Error
       tags:
         - /internal
-  /internal/document/{id}:
+  /internal/file/{id}:
     delete:
       operationId: DocumentHandler.Delete
       parameters:
@@ -244,7 +244,7 @@ paths:
           description: Internal Server Error
       tags:
         - /internal
-  /internal/document/{id}/content:
+  /internal/file/{id}/content:
     get:
       operationId: DocumentHandler.GetContent
       parameters:
@@ -314,7 +314,7 @@ paths:
           description: Internal Server Error
       tags:
         - /internal
-  /internal/document/{id}/meta:
+  /internal/file/{id}/meta:
     get:
       operationId: DocumentHandler.GetMeta
       parameters:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -344,7 +344,7 @@ paths:
           description: Internal Server Error
       tags:
         - /internal
-  /rest/storage/document/{id}:
+  /rest/storage/file/{id}:
     get:
       operationId: PublicHandler.ServeDocument
       parameters:


### PR DESCRIPTION
## Summary
- DB table `document` → `file` (aligned with server's `@Entity('file')`)
- Internal API: `/internal/document/...` → `/internal/file/...`
- Public API: `/rest/storage/file/:id` (new canonical), `/rest/storage/document/:id` (backward compat alias)
- Regenerated sqlc queries and openapi.yaml

## Test plan
- [x] All tests pass except alkemiodb integration (expected — needs DB migration)
- [x] Lint clean
- [x] Router tests updated to `/internal/file/...` paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **API Changes**
  * File management endpoints renamed from /document to /file; public storage route keeps a /document alias for backward compatibility and a new /rest/storage/file/{id} public path added.

* **Documentation**
  * API specification updated to reflect endpoint renames.

* **Infrastructure**
  * Deployment configuration updated: resources, probes, storage mount, image/config, and pod affinity adjusted for improved reliability.

* **CI**
  * CI tooling pinned to a specific codegen tool version for consistent builds and tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->