### PR TITLE
Fix HEIC support, return 422 for image processing errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ FROM golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS builder
 WORKDIR /app
 
 # Install build dependencies (vips-dev for CGO image processing)
-RUN apk add --no-cache git wget vips-dev gcc musl-dev
+RUN apk add --no-cache git wget vips-dev vips-heif vips-jxl vips-poppler gcc musl-dev
 
 # Download the wait script (architecture-specific)
 ARG TARGETARCH
@@ -35,7 +35,7 @@ RUN CGO_ENABLED=1 go build -tags vips -trimpath -ldflags "-s -w" -o /bin/file-se
 FROM alpine:${ALPINE_VERSION}
 
 # Install libvips runtime only
-RUN apk add --no-cache vips
+RUN apk add --no-cache vips vips-heif vips-jxl vips-poppler
 
 # Non-root user matching K8s securityContext (fsGroup: 65532)
 RUN addgroup -g 65532 -S nonroot && adduser -u 65532 -S -G nonroot nonroot

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ FROM golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS builder
 WORKDIR /app
 
 # Install build dependencies (vips-dev for CGO image processing)
-RUN apk add --no-cache git wget vips-dev vips-heif vips-jxl vips-poppler gcc musl-dev
+RUN apk add --no-cache git wget vips-dev gcc musl-dev
 
 # Download the wait script (architecture-specific)
 ARG TARGETARCH

--- a/internal/adapter/inbound/http/document_handler.go
+++ b/internal/adapter/inbound/http/document_handler.go
@@ -199,6 +199,8 @@ func (h *DocumentHandler) Create(w http.ResponseWriter, r *http.Request) {
 			writeJSONError(w, http.StatusRequestEntityTooLarge, "file too large")
 		case errors.Is(err, service.ErrUnsupportedMediaType):
 			writeJSONError(w, http.StatusUnsupportedMediaType, "unsupported media type")
+		case errors.Is(err, service.ErrImageProcessing):
+			writeJSONError(w, http.StatusUnprocessableEntity, err.Error())
 		default:
 			h.Logger.Error("failed to create document", zap.Error(err))
 			writeJSONError(w, http.StatusInternalServerError, "internal error")
@@ -330,12 +332,15 @@ func (h *DocumentHandler) ReplaceContent(w http.ResponseWriter, r *http.Request)
 
 	result, err := h.Service.StoreAndLink(r.Context(), docID, content)
 	if err != nil {
-		if errors.Is(err, model.ErrDocumentNotFound) {
+		switch {
+		case errors.Is(err, model.ErrDocumentNotFound):
 			writeJSONError(w, http.StatusNotFound, "document not found")
-			return
+		case errors.Is(err, service.ErrImageProcessing):
+			writeJSONError(w, http.StatusUnprocessableEntity, err.Error())
+		default:
+			h.Logger.Error("failed to replace content", zap.Error(err))
+			writeJSONError(w, http.StatusInternalServerError, "internal error")
 		}
-		h.Logger.Error("failed to replace content", zap.Error(err))
-		writeJSONError(w, http.StatusInternalServerError, "internal error")
 		return
 	}
 

--- a/internal/adapter/outbound/alkemiodb/adapter_test.go
+++ b/internal/adapter/outbound/alkemiodb/adapter_test.go
@@ -35,7 +35,7 @@ func TestGetByID_ExistingDocument(t *testing.T) {
 	a := New(pool)
 
 	// Use a known document from the DB
-	rows, err := pool.Query(context.Background(), `SELECT id FROM document LIMIT 1`)
+	rows, err := pool.Query(context.Background(), `SELECT id FROM file LIMIT 1`)
 	if err != nil {
 		t.Fatalf("query: %v", err)
 	}
@@ -84,7 +84,7 @@ func TestCreateAndDelete(t *testing.T) {
 	// We need valid FK references. Get a storageBucket and authorization from an existing doc.
 	var storageBucketID, authorizationID [16]byte
 	err := pool.QueryRow(context.Background(),
-		`SELECT "storageBucketId", "authorizationId" FROM document WHERE "storageBucketId" IS NOT NULL AND "authorizationId" IS NOT NULL LIMIT 1`,
+		`SELECT "storageBucketId", "authorizationId" FROM file WHERE "storageBucketId" IS NOT NULL AND "authorizationId" IS NOT NULL LIMIT 1`,
 	).Scan(&storageBucketID, &authorizationID)
 	if err != nil {
 		t.Skipf("no document with valid FKs: %v", err)
@@ -163,7 +163,7 @@ func TestUpdateFile(t *testing.T) {
 	var origExtID, origMime string
 	var origSize int32
 	err := pool.QueryRow(context.Background(),
-		`SELECT id, "externalID", "mimeType", size FROM document LIMIT 1`,
+		`SELECT id, "externalID", "mimeType", size FROM file LIMIT 1`,
 	).Scan(&id, &origExtID, &origMime, &origSize)
 	if err != nil {
 		t.Skip("no documents")
@@ -206,7 +206,7 @@ func TestCountByExternalID(t *testing.T) {
 	// Known hash from existing data
 	var extID string
 	err := pool.QueryRow(context.Background(),
-		`SELECT "externalID" FROM document LIMIT 1`,
+		`SELECT "externalID" FROM file LIMIT 1`,
 	).Scan(&extID)
 	if err != nil {
 		t.Skip("no documents")
@@ -239,7 +239,7 @@ func TestUpdateLocation(t *testing.T) {
 	var tempLoc bool
 	var version int32
 	err := pool.QueryRow(context.Background(),
-		`SELECT id, "storageBucketId", "temporaryLocation", version FROM document LIMIT 1`,
+		`SELECT id, "storageBucketId", "temporaryLocation", version FROM file LIMIT 1`,
 	).Scan(&id, &bucketID, &tempLoc, &version)
 	if err != nil {
 		t.Skip("no documents")

--- a/internal/domain/service/file_service.go
+++ b/internal/domain/service/file_service.go
@@ -88,7 +88,7 @@ func (s *FileService) CreateDocument(ctx context.Context, input model.CreateDocu
 
 	processed, finalMIME, err := s.Processor.Process(content, mimeType)
 	if err != nil {
-		return nil, fmt.Errorf("image processing: %w", err)
+		return nil, fmt.Errorf("%w: %w", ErrImageProcessing, err)
 	}
 
 	stored, err := s.Storage.Save(processed)
@@ -177,7 +177,7 @@ func (s *FileService) StoreAndLink(ctx context.Context, documentID uuid.UUID, co
 	mimeType := normalizeMIME(s.Processor.DetectMIME(content))
 	processed, finalMIME, err := s.Processor.Process(content, mimeType)
 	if err != nil {
-		return nil, fmt.Errorf("image processing: %w", err)
+		return nil, fmt.Errorf("%w: %w", ErrImageProcessing, err)
 	}
 
 	stored, err := s.Storage.Save(processed)
@@ -239,6 +239,7 @@ var (
 	ErrConflict             = errors.New("conflict: document was modified concurrently")
 	ErrPayloadTooLarge      = errors.New("payload too large")
 	ErrUnsupportedMediaType = errors.New("unsupported media type")
+	ErrImageProcessing      = errors.New("image processing failed")
 )
 
 // normalizeMIME strips parameters and lowercases a MIME type.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -162,6 +162,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/http.errorResponse'
           description: Unsupported Media Type
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/http.errorResponse'
+          description: Unprocessable Entity
         "500":
           content:
             application/json:
@@ -306,6 +312,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/http.errorResponse'
           description: Request Entity Too Large
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/http.errorResponse'
+          description: Unprocessable Entity
         "500":
           content:
             application/json:


### PR DESCRIPTION
## Summary
- Docker image missing HEIF support — added `vips-heif`, `vips-jxl`, `vips-poppler` packages
- Image processing errors (unsupported format, conversion failure) returned 500 — now return 422
- Added `ErrImageProcessing` sentinel error for proper classification in handlers

## Test plan
- [x] Docker image builds successfully with all format plugins
- [x] All tests pass (except alkemiodb integration — pending DB table rename)
- [x] Lint clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for HEIF, JXL and PDF image formats.

* **Chores**
  * Runtime image stack now includes the codecs/plugins needed for those formats.

* **Bug Fixes**
  * Image-processing failures now return clearer, specific HTTP 422 responses to aid troubleshooting.

* **Documentation**
  * API spec updated to document 422 responses for the internal file upload/content endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->