### PR TITLE
Pre-create /storage with nonroot ownership

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,9 @@ WORKDIR /app
 COPY --from=builder /wait /wait
 COPY --from=builder /bin/file-service /bin/file-service
 
+RUN mkdir /storage && chown nonroot:nonroot /storage
+VOLUME /storage
+
 USER nonroot:nonroot
 
 EXPOSE 4003


### PR DESCRIPTION
## Summary
- Pre-create `/storage` directory owned by `nonroot:nonroot` in the Docker image
- Add `VOLUME /storage` declaration
- Named volumes inherit ownership from the image, fixing write permission issues

## Test plan
- [x] Docker build succeeds
- [x] `/storage` owned by `nonroot:nonroot` verified in container

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved storage persistence configuration to ensure data is retained across container restarts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->