### PR TITLE
Split liveness from readiness: add /live endpoint

### DIFF
--- a/internal/adapter/inbound/http/middleware.go
+++ b/internal/adapter/inbound/http/middleware.go
@@ -86,6 +86,8 @@ func JWTExtractor(next http.Handler) http.Handler {
 }
 
 // RequestLogger logs request start/end with duration.
+// Health-probe endpoints (/live, /health) are excluded from logs: they are hit
+// by Kubernetes probes every few seconds and would dominate the log stream.
 func RequestLogger(logger *zap.Logger) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -93,6 +95,10 @@ func RequestLogger(logger *zap.Logger) func(http.Handler) http.Handler {
 			ww := &statusWriter{ResponseWriter: w, status: http.StatusOK}
 
 			next.ServeHTTP(ww, r)
+
+			if r.URL.Path == "/live" || r.URL.Path == "/health" {
+				return
+			}
 
 			logger.Info("request",
 				zap.String("requestID", GetRequestID(r.Context())),

--- a/internal/adapter/inbound/http/middleware.go
+++ b/internal/adapter/inbound/http/middleware.go
@@ -96,7 +96,7 @@ func RequestLogger(logger *zap.Logger) func(http.Handler) http.Handler {
 
 			next.ServeHTTP(ww, r)
 
-			if r.URL.Path == "/live" || r.URL.Path == "/health" {
+			if r.Method == http.MethodGet && (r.URL.Path == "/live" || r.URL.Path == "/health") {
 				return
 			}
 

--- a/internal/adapter/inbound/http/router.go
+++ b/internal/adapter/inbound/http/router.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"encoding/json"
 	"expvar"
 	"net/http"
 
@@ -8,6 +9,23 @@ import (
 	chimw "github.com/go-chi/chi/v5/middleware"
 	"go.uber.org/zap"
 )
+
+// LiveResponse is the body returned by GET /live.
+type LiveResponse struct {
+	Status string `json:"status"`
+}
+
+// ServeLive is the K8s liveness handler: returns 200 unconditionally so the
+// probe reflects process-alive only, independent of DB/NATS availability.
+func ServeLive(w http.ResponseWriter, _ *http.Request) {
+	LiveResponse{Status: "alive"}.Render(w)
+}
+
+func (r LiveResponse) Render(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(r)
+}
 
 // Deps contains all handler dependencies.
 type Deps struct {
@@ -28,11 +46,7 @@ func NewRouter(deps Deps) *chi.Mux {
 	// Liveness (K8s livenessProbe): process-alive check only, no dependencies.
 	// Kept separate from /health so liveness failures don't restart pods when
 	// only a dependency is down.
-	r.Get("/live", func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"status":"alive"}`))
-	})
+	r.Get("/live", ServeLive)
 
 	// Readiness (K8s readinessProbe): checks DB (and NATS if configured).
 	r.Method("GET", "/health", deps.HealthHandler)

--- a/internal/adapter/inbound/http/router.go
+++ b/internal/adapter/inbound/http/router.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"expvar"
+	"net/http"
 
 	"github.com/go-chi/chi/v5"
 	chimw "github.com/go-chi/chi/v5/middleware"
@@ -24,7 +25,16 @@ func NewRouter(deps Deps) *chi.Mux {
 	r.Use(RequestID)
 	r.Use(RequestLogger(deps.Logger))
 
-	// Health check (root level)
+	// Liveness (K8s livenessProbe): process-alive check only, no dependencies.
+	// Kept separate from /health so liveness failures don't restart pods when
+	// only a dependency is down.
+	r.Get("/live", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"alive"}`))
+	})
+
+	// Readiness (K8s readinessProbe): checks DB (and NATS if configured).
 	r.Method("GET", "/health", deps.HealthHandler)
 
 	// Public endpoints (Oathkeeper strips /api/private, arrives as /rest/storage/...)

--- a/internal/adapter/inbound/http/router_test.go
+++ b/internal/adapter/inbound/http/router_test.go
@@ -59,6 +59,24 @@ func TestRouter_HealthEndpoint(t *testing.T) {
 	}
 }
 
+// /live is a process-alive check for K8s livenessProbe. It must return 200
+// regardless of DB/NATS state — the point is to detect deadlocked pods, not
+// dependency failures.
+func TestRouter_LiveEndpoint(t *testing.T) {
+	r := testRouter()
+
+	req := httptest.NewRequest(http.MethodGet, "/live", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("GET /live = %d, want 200", rr.Code)
+	}
+	if ct := rr.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+}
+
 func TestRouter_DebugVars(t *testing.T) {
 	r := testRouter()
 

--- a/internal/adapter/inbound/http/router_test.go
+++ b/internal/adapter/inbound/http/router_test.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -63,18 +64,42 @@ func TestRouter_HealthEndpoint(t *testing.T) {
 // regardless of DB/NATS state — the point is to detect deadlocked pods, not
 // dependency failures.
 func TestRouter_LiveEndpoint(t *testing.T) {
-	r := testRouter()
+	t.Run("HealthyDeps", func(t *testing.T) {
+		r := testRouter()
+		req := httptest.NewRequest(http.MethodGet, "/live", nil)
+		rr := httptest.NewRecorder()
+		r.ServeHTTP(rr, req)
 
-	req := httptest.NewRequest(http.MethodGet, "/live", nil)
-	rr := httptest.NewRecorder()
-	r.ServeHTTP(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Errorf("GET /live = %d, want 200", rr.Code)
+		}
+		if ct := rr.Header().Get("Content-Type"); ct != "application/json" {
+			t.Errorf("Content-Type = %q, want application/json", ct)
+		}
+	})
 
-	if rr.Code != http.StatusOK {
-		t.Errorf("GET /live = %d, want 200", rr.Code)
-	}
-	if ct := rr.Header().Get("Content-Type"); ct != "application/json" {
-		t.Errorf("Content-Type = %q, want application/json", ct)
-	}
+	// Critical invariant: /live MUST return 200 even when readiness dependencies
+	// are broken. Liveness = process alive; dependency health belongs to /health.
+	t.Run("BrokenDeps", func(t *testing.T) {
+		logger, _ := zap.NewDevelopment()
+		r := NewRouter(Deps{
+			PublicHandler:   &PublicHandler{},
+			DocumentHandler: &DocumentHandler{},
+			HealthHandler: &HealthHandler{
+				DB:   &mockPinger{err: errors.New("db down")},
+				NATS: &mockConnChecker{connected: false},
+			},
+			Logger: logger,
+		})
+
+		req := httptest.NewRequest(http.MethodGet, "/live", nil)
+		rr := httptest.NewRecorder()
+		r.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusOK {
+			t.Errorf("GET /live with broken deps = %d, want 200 (liveness must not depend on readiness)", rr.Code)
+		}
+	})
 }
 
 func TestRouter_DebugVars(t *testing.T) {

--- a/manifests/25-file-service-deployment-dev.yaml
+++ b/manifests/25-file-service-deployment-dev.yaml
@@ -56,19 +56,24 @@ spec:
           volumeMounts:
             - name: file-storage
               mountPath: /storage
+          # Readiness: checks dependencies (DB, NATS). Pulls pod from Service
+          # when deps are unreachable so traffic doesn't hit a broken instance.
           readinessProbe:
             httpGet:
               path: /health
               port: 4003
             initialDelaySeconds: 5
-            periodSeconds: 10
+            periodSeconds: 30
             failureThreshold: 3
+          # Liveness: process-alive check only, no deps. Restarting the pod
+          # when the DB is down would not fix anything and would amplify an
+          # outage. Separate /live endpoint avoids that.
           livenessProbe:
             httpGet:
-              path: /health
+              path: /live
               port: 4003
             initialDelaySeconds: 5
-            periodSeconds: 10
+            periodSeconds: 30
             failureThreshold: 3
           resources:
             requests:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -68,6 +68,13 @@ components:
         - createdDate
         - updatedDate
       type: object
+    http.LiveResponse:
+      properties:
+        status:
+          type: string
+      required:
+        - status
+      type: object
     http.ReplaceContentResponse:
       properties:
         externalID:
@@ -367,14 +374,17 @@ paths:
         - /internal
   /live:
     get:
-      operationId: router.go:31:17
+      operationId: http.ServeLive
       responses:
         "200":
           content:
             application/json:
               schema:
-                type: string
+                $ref: '#/components/schemas/http.LiveResponse'
           description: OK
+      summary: |-
+        ServeLive is the K8s liveness handler: returns 200 unconditionally so the
+        probe reflects process-alive only, independent of DB/NATS availability.
   /rest/storage/file/{id}:
     get:
       operationId: PublicHandler.ServeDocument

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -365,6 +365,16 @@ paths:
           description: Internal Server Error
       tags:
         - /internal
+  /live:
+    get:
+      operationId: router.go:31:17
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: string
+          description: OK
   /rest/storage/file/{id}:
     get:
       operationId: PublicHandler.ServeDocument


### PR DESCRIPTION
## Summary
- Add `/live` endpoint for K8s `livenessProbe` — returns 200 unconditionally, no dependency checks
- Keep `/health` for `readinessProbe` (DB + NATS checks as before)
- Suppress request logging for both `/live` and `/health` to stop log spam from constant probe traffic
- Dev manifest switched to the split probes, `periodSeconds: 10 → 30`

## Why
Current setup hits `/health` for both probes, causing Postgres `Ping` on every liveness probe. When the DB is down, liveness fails and K8s restarts the pod — which doesn't fix anything and amplifies an outage.

## Test plan
- [x] `TestRouter_LiveEndpoint` added
- [x] Full test + lint clean
- [x] OpenAPI regenerated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated liveness probe endpoint (GET /live) that always returns 200 with a JSON status.

* **Improvements**
  * Probe requests (e.g., /live and /health) are now suppressed in standard request logs for cleaner logging.

* **Documentation**
  * OpenAPI/docs updated to include the new liveness endpoint and response schema.

* **Tests**
  * Added tests validating the liveness endpoint behavior and JSON response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->