### PR TITLE
Accept legacy IPFS CID externalIDs in storage validator

### DIFF
--- a/internal/adapter/outbound/storage/local/adapter.go
+++ b/internal/adapter/outbound/storage/local/adapter.go
@@ -105,13 +105,25 @@ func (a *Adapter) filePath(externalID string) string {
 	return filepath.Join(a.basePath, externalID)
 }
 
-// isValidExternalID checks that the ID is a valid SHA3-256 hex string (64 lowercase hex chars).
+// isValidExternalID rejects path-traversal attempts and other dangerous
+// characters in storage IDs. Accepts both formats produced across the
+// service's history:
+//   - SHA3-256 hex: 64 lowercase hex chars (current Go file-service format)
+//   - IPFS CIDv0:   46 base58btc chars starting with "Qm" (legacy TS file-service)
+//
+// Conservative allow-list: alphanumeric only, length 32-128. This blocks
+// '/', '\', '.', '..', NUL, control chars, whitespace — anything that
+// could escape the basePath.
 func isValidExternalID(id string) bool {
-	if len(id) != 64 {
+	if len(id) < 32 || len(id) > 128 {
 		return false
 	}
 	for _, c := range id {
-		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
+		switch {
+		case c >= '0' && c <= '9':
+		case c >= 'a' && c <= 'z':
+		case c >= 'A' && c <= 'Z':
+		default:
 			return false
 		}
 	}

--- a/internal/adapter/outbound/storage/local/adapter_test.go
+++ b/internal/adapter/outbound/storage/local/adapter_test.go
@@ -3,6 +3,7 @@ package local
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/alkem-io/file-service-go/internal/domain/service"
@@ -249,7 +250,7 @@ func TestIsValidExternalID(t *testing.T) {
 		// Reject: length bounds
 		{"too short", "abc", false},
 		{"empty", "", false},
-		{"too long", string(make([]byte, 200)), false},
+		{"too long", strings.Repeat("a", 129), false}, // valid chars, just exceeds max length 128
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/adapter/outbound/storage/local/adapter_test.go
+++ b/internal/adapter/outbound/storage/local/adapter_test.go
@@ -227,3 +227,35 @@ func TestExists_InvalidExternalID(t *testing.T) {
 		t.Fatal("expected error for invalid external ID")
 	}
 }
+
+func TestIsValidExternalID(t *testing.T) {
+	cases := []struct {
+		name string
+		id   string
+		want bool
+	}{
+		// Accept: current SHA3-256 hex format
+		{"sha3 lowercase hex", "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789", true},
+		// Accept: legacy IPFS CIDv0 (base58btc, starts with Qm)
+		{"ipfs CIDv0", "QmeNLuvfd2yxaXRPDTSb2k9LxspUucqh7dSzJ7pttxKjhD", true},
+		{"ipfs CIDv0 mixed case", "QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG", true},
+		// Reject: path traversal & special chars
+		{"path traversal", "../etc/passwd", false},
+		{"forward slash", "abc/def0123456789abcdef0123456789abcdef0123456789abcdef0123456789", false},
+		{"backslash", "abc\\def0123456789abcdef0123456789abcdef0123456789abcdef0123456789", false},
+		{"dot", "abc.def0123456789abcdef0123456789abcdef0123456789abcdef0123456789", false},
+		{"nul byte", "abc\x00def0123456789abcdef0123456789abcdef0123456789abcdef0123456789", false},
+		{"hyphen", "abc-def0123456789abcdef0123456789abcdef0123456789abcdef0123456789", false},
+		// Reject: length bounds
+		{"too short", "abc", false},
+		{"empty", "", false},
+		{"too long", string(make([]byte, 200)), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isValidExternalID(tc.id); got != tc.want {
+				t.Errorf("isValidExternalID(%q) = %v, want %v", tc.id, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
The validator only accepted SHA3-256 hex (64 lowercase hex chars), causing every pre-migration document with an IPFS CIDv0 externalID to fail with \`invalid external ID\` — even when the file existed on disk.

## Fix
Loosened the allow-list to \`[0-9A-Za-z]\` with length 32-128. This still rejects path-traversal chars (\`/\`, \`\\\`, \`.\`, NUL, control chars) while covering both:
- SHA3-256 hex (64 chars, lowercase) — current Go format
- IPFS CIDv0 (46 chars, base58btc, starts with \`Qm\`) — legacy TS format

## Test plan
- [x] New \`TestIsValidExternalID\` covers both accepted formats and 8 reject cases (path traversal, slashes, dot, NUL, hyphen, length bounds)
- [x] Existing tests still pass (path-traversal cases unchanged)
- [x] Lint clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened storage identifier validation to block path-traversal and other unsafe inputs.

* **New Features**
  * Broadened accepted storage identifier formats to support current and legacy IDs.

* **Tests**
  * Added comprehensive unit tests covering valid/invalid identifier formats and security edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->