### PR TITLE
Add skipDedup opt-out flag to POST /internal/file

### DIFF
--- a/internal/adapter/inbound/http/document_handler.go
+++ b/internal/adapter/inbound/http/document_handler.go
@@ -139,6 +139,15 @@ func parseCreateForm(r *http.Request) (content []byte, declaredMIME string, inpu
 		temporaryLocation = parsed
 	}
 
+	skipDedup := false
+	if v := r.FormValue("skipDedup"); v != "" {
+		parsed, err := strconv.ParseBool(v)
+		if err != nil {
+			return nil, "", input, nil, 0, fmt.Errorf("invalid skipDedup: must be true or false")
+		}
+		skipDedup = parsed
+	}
+
 	if v := r.FormValue("allowedMimeTypes"); v != "" {
 		parts := strings.Split(v, ",")
 		for _, p := range parts {
@@ -163,6 +172,7 @@ func parseCreateForm(r *http.Request) (content []byte, declaredMIME string, inpu
 		StorageBucketID:   storageBucketID,
 		AuthorizationID:   authorizationID,
 		TagsetID:          tagsetID,
+		SkipDedup:         skipDedup,
 	}
 
 	return content, declaredMIME, input, allowedMimeTypes, maxFileSize, nil
@@ -201,6 +211,10 @@ func (h *DocumentHandler) Create(w http.ResponseWriter, r *http.Request) {
 			writeJSONError(w, http.StatusUnsupportedMediaType, "unsupported media type")
 		case errors.Is(err, service.ErrImageProcessing):
 			writeJSONError(w, http.StatusUnprocessableEntity, err.Error())
+		case errors.Is(err, service.ErrConflict):
+			// Reachable only when SkipDedup=true and a row with this
+			// (externalID, storageBucketID) already exists.
+			writeJSONError(w, http.StatusConflict, "skipDedup requested but a row with this content already exists in the bucket")
 		default:
 			h.Logger.Error("failed to create document", zap.Error(err))
 			writeJSONError(w, http.StatusInternalServerError, "internal error")

--- a/internal/adapter/inbound/http/document_handler_test.go
+++ b/internal/adapter/inbound/http/document_handler_test.go
@@ -299,6 +299,37 @@ func TestDocumentHandler_Create_SkipDedup_BypassesDedup(t *testing.T) {
 	}
 }
 
+// HTTP-level coverage for the ErrConflict → 409 mapping in the Create handler.
+// Reachable when SkipDedup=true and the schema enforces unique(externalID,
+// storageBucketID); the service surfaces ErrConflict rather than
+// masquerading as Reused=true.
+func TestDocumentHandler_Create_SkipDedup_Conflict_Returns409(t *testing.T) {
+	h, repo, _ := newDocHandler()
+	repo.createErr = model.ErrDuplicateKey
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	part, _ := writer.CreateFormFile("file", "placeholder.docx")
+	_, _ = part.Write([]byte("hello"))
+	_ = writer.WriteField("displayName", "placeholder.docx")
+	_ = writer.WriteField("storageBucketId", uuid.New().String())
+	_ = writer.WriteField("authorizationId", uuid.New().String())
+	_ = writer.WriteField("skipDedup", "true")
+	_ = writer.Close()
+
+	r := chi.NewRouter()
+	r.Post("/internal/file", h.Create)
+
+	req := httptest.NewRequest(http.MethodPost, "/internal/file", &body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409, body: %s", rr.Code, rr.Body.String())
+	}
+}
+
 // Malformed skipDedup value → 400.
 func TestDocumentHandler_Create_SkipDedup_InvalidValue_400(t *testing.T) {
 	h, _, _ := newDocHandler()

--- a/internal/adapter/inbound/http/document_handler_test.go
+++ b/internal/adapter/inbound/http/document_handler_test.go
@@ -257,6 +257,75 @@ func TestDocumentHandler_Create_Dedup_ReturnsReusedTrue(t *testing.T) {
 	}
 }
 
+// skipDedup=true on the multipart form must bypass the dedup lookup even when
+// an existing row matches. Returns 201 (uniform POST) with reused=false.
+func TestDocumentHandler_Create_SkipDedup_BypassesDedup(t *testing.T) {
+	h, repo, _ := newDocHandler()
+
+	bucket := uuid.New()
+	repo.findDoc = &model.Document{
+		ID:              uuid.New(),
+		ExternalID:      "sha3-of-hello",
+		MimeType:        "text/plain",
+		StorageBucketID: bucket,
+		AuthorizationID: uuid.New(),
+	}
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	part, _ := writer.CreateFormFile("file", "placeholder.docx")
+	_, _ = part.Write([]byte("hello"))
+	_ = writer.WriteField("displayName", "placeholder.docx")
+	_ = writer.WriteField("storageBucketId", bucket.String())
+	_ = writer.WriteField("authorizationId", uuid.New().String())
+	_ = writer.WriteField("skipDedup", "true")
+	_ = writer.Close()
+
+	r := chi.NewRouter()
+	r.Post("/internal/file", h.Create)
+
+	req := httptest.NewRequest(http.MethodPost, "/internal/file", &body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201, body: %s", rr.Code, rr.Body.String())
+	}
+	var resp map[string]any
+	_ = json.Unmarshal(rr.Body.Bytes(), &resp)
+	if reused, ok := resp["reused"].(bool); !ok || reused {
+		t.Errorf("reused = %v, want false (skipDedup bypasses dedup)", resp["reused"])
+	}
+}
+
+// Malformed skipDedup value → 400.
+func TestDocumentHandler_Create_SkipDedup_InvalidValue_400(t *testing.T) {
+	h, _, _ := newDocHandler()
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	part, _ := writer.CreateFormFile("file", "test.txt")
+	_, _ = part.Write([]byte("hello"))
+	_ = writer.WriteField("displayName", "test.txt")
+	_ = writer.WriteField("storageBucketId", uuid.New().String())
+	_ = writer.WriteField("authorizationId", uuid.New().String())
+	_ = writer.WriteField("skipDedup", "yes-please") // invalid bool
+	_ = writer.Close()
+
+	r := chi.NewRouter()
+	r.Post("/internal/file", h.Create)
+
+	req := httptest.NewRequest(http.MethodPost, "/internal/file", &body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400 for malformed skipDedup", rr.Code)
+	}
+}
+
 func TestDocumentHandler_Create_AllFields(t *testing.T) {
 	h, _, _ := newDocHandler()
 

--- a/internal/domain/model/document.go
+++ b/internal/domain/model/document.go
@@ -37,6 +37,14 @@ type CreateDocumentInput struct {
 	StorageBucketID   uuid.UUID
 	AuthorizationID   uuid.UUID
 	TagsetID          *uuid.UUID
+
+	// SkipDedup, when true, bypasses the per-bucket content-hash dedup
+	// lookup and forces a fresh row insert even if an existing row in the
+	// same bucket has the same externalID. Use case: placeholder uploads
+	// (e.g., empty buffers for Collabora documents) where two logical
+	// documents must NOT share a backing row even though their content
+	// hashes match. Default false preserves the dedup behavior.
+	SkipDedup bool
 }
 
 // StoredFile represents the result of a file storage operation.

--- a/internal/domain/service/file_service.go
+++ b/internal/domain/service/file_service.go
@@ -79,6 +79,16 @@ func (s *FileService) CreateDocument(ctx context.Context, input model.CreateDocu
 		return nil, fmt.Errorf("store file: %w", err)
 	}
 
+	// Caller opt-out: skip the dedup lookup and force a fresh row insert
+	// even when an existing row in this bucket has the same externalID.
+	// Used by placeholder flows (e.g., Collabora documents) where two
+	// logical documents must NOT share a backing row even if their content
+	// hashes collide. The caller-supplied AuthorizationID / TagsetID are
+	// honored on the new row.
+	if input.SkipDedup {
+		return s.insertDocument(ctx, input, stored, finalMIME)
+	}
+
 	// Row-level dedup: if a file row already exists for (externalID, storageBucketID),
 	// return it as-is. The caller-supplied AuthorizationID / TagsetID are ignored —
 	// the existing row's values are authoritative. Caller must use Reused=true to
@@ -162,9 +172,17 @@ func (s *FileService) insertDocument(ctx context.Context, input model.CreateDocu
 		return &doc, nil
 	}
 
-	// Concurrent creator won the race on the unique(externalID, storageBucketID) index.
-	// Re-query and return the winner with Reused=true.
 	if errors.Is(err, model.ErrDuplicateKey) {
+		// SkipDedup means the caller explicitly asked for a fresh row. If the
+		// schema enforces unique(externalID, storageBucketID), we can't honor
+		// that intent — surface as ErrConflict rather than masquerading as a
+		// dedup hit (which would silently corrupt placeholder flows).
+		if input.SkipDedup {
+			return nil, ErrConflict
+		}
+		// Default path: another concurrent creator won the race on the
+		// unique(externalID, storageBucketID) index. Re-query and return
+		// the winner with Reused=true.
 		raced, findErr := s.Repo.FindByExternalIDAndBucket(ctx, stored.ExternalID, input.StorageBucketID)
 		if findErr == nil {
 			raced.Reused = true

--- a/internal/domain/service/file_service_test.go
+++ b/internal/domain/service/file_service_test.go
@@ -300,6 +300,143 @@ func TestCreateDocument_Dedup_CreateRace_ReturnsWinnerAsReused(t *testing.T) {
 	}
 }
 
+// SkipDedup: true → fresh row inserted even when an existing row matches.
+// Lookup must NOT be called; existing row must NOT be returned/mutated.
+func TestCreateDocument_SkipDedup_InsertsFreshRowWhenContentExists(t *testing.T) {
+	bucket := uuid.New()
+	repo := &mockRepo{
+		// findDoc set deliberately — proves we never even call FindByExternalIDAndBucket.
+		findDoc: &model.Document{
+			ID:              uuid.New(),
+			ExternalID:      "sha3-of-content",
+			StorageBucketID: bucket,
+			AuthorizationID: uuid.New(),
+		},
+	}
+	svc := &FileService{Logger: nopLogger, Repo: repo, Storage: &mockStorage{}, Processor: &mockProcessor{}}
+
+	callerAuth := uuid.New()
+	callerTagset := uuid.New()
+	input := model.CreateDocumentInput{
+		DisplayName:     "placeholder.docx",
+		StorageBucketID: bucket,
+		AuthorizationID: callerAuth,
+		TagsetID:        &callerTagset,
+		SkipDedup:       true,
+	}
+
+	doc, err := svc.CreateDocument(context.Background(), input, []byte("content"), "", nil, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if doc.Reused {
+		t.Error("expected Reused=false when SkipDedup=true")
+	}
+	if repo.findCalls != 0 {
+		t.Errorf("expected 0 FindByExternalIDAndBucket calls when SkipDedup=true, got %d", repo.findCalls)
+	}
+	if repo.createCalls != 1 {
+		t.Errorf("expected 1 Create call, got %d", repo.createCalls)
+	}
+	if doc.AuthorizationID != callerAuth {
+		t.Errorf("AuthorizationID = %v, want caller-supplied %v (existing row's auth must not leak in)", doc.AuthorizationID, callerAuth)
+	}
+	if doc.TagsetID == nil || *doc.TagsetID != callerTagset {
+		t.Errorf("TagsetID = %v, want caller-supplied %v", doc.TagsetID, callerTagset)
+	}
+}
+
+// SkipDedup: true with empty content → still gets a fresh row.
+// This is the Collabora placeholder path: 0-byte create that must not
+// merge with another empty-content row in the same bucket.
+func TestCreateDocument_SkipDedup_EmptyContent_GetsFreshRow(t *testing.T) {
+	bucket := uuid.New()
+	repo := &mockRepo{
+		findDoc: &model.Document{
+			ID:              uuid.New(),
+			ExternalID:      "sha3-of-empty",
+			StorageBucketID: bucket,
+			AuthorizationID: uuid.New(),
+		},
+	}
+	svc := &FileService{Logger: nopLogger, Repo: repo, Storage: &mockStorage{}, Processor: &mockProcessor{}}
+
+	input := model.CreateDocumentInput{
+		DisplayName:     "doc.docx",
+		StorageBucketID: bucket,
+		AuthorizationID: uuid.New(),
+		SkipDedup:       true,
+	}
+	doc, err := svc.CreateDocument(context.Background(), input, []byte{}, "application/vnd.openxmlformats-officedocument.wordprocessingml.document", []string{"application/vnd.openxmlformats-officedocument.wordprocessingml.document"}, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if doc.Reused {
+		t.Error("expected Reused=false for skipDedup placeholder")
+	}
+	if repo.findCalls != 0 {
+		t.Errorf("expected 0 FindByExternalIDAndBucket calls, got %d", repo.findCalls)
+	}
+}
+
+// SkipDedup default false → backward-compatible: existing dedup behavior preserved.
+// This is the regression guard against accidentally turning dedup off for everyone.
+func TestCreateDocument_SkipDedupOmitted_DedupStillApplies(t *testing.T) {
+	existingID := uuid.New()
+	bucket := uuid.New()
+	repo := &mockRepo{
+		findDoc: &model.Document{
+			ID:              existingID,
+			ExternalID:      "sha3-of-content",
+			StorageBucketID: bucket,
+			AuthorizationID: uuid.New(),
+		},
+	}
+	svc := &FileService{Logger: nopLogger, Repo: repo, Storage: &mockStorage{}, Processor: &mockProcessor{}}
+
+	input := model.CreateDocumentInput{
+		DisplayName:     "test.txt",
+		StorageBucketID: bucket,
+		AuthorizationID: uuid.New(),
+		// SkipDedup omitted → defaults to false
+	}
+	doc, err := svc.CreateDocument(context.Background(), input, []byte("content"), "", nil, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !doc.Reused {
+		t.Error("expected Reused=true (default dedup path)")
+	}
+	if doc.ID != existingID {
+		t.Errorf("expected existing row ID %v, got %v", existingID, doc.ID)
+	}
+}
+
+// SkipDedup hits the unique index: surface as ErrConflict, not Reused=true.
+// Server-side may add unique(externalID, storageBucketID); if present, a
+// SkipDedup placeholder collision must error rather than silently coalesce.
+func TestCreateDocument_SkipDedup_DuplicateKey_ReturnsConflict(t *testing.T) {
+	repo := &mockRepoRace{
+		find: func() (model.Document, error) {
+			t.Fatal("FindByExternalIDAndBucket must not be called when SkipDedup=true")
+			return model.Document{}, nil
+		},
+		createErr: model.ErrDuplicateKey,
+	}
+	svc := &FileService{Logger: nopLogger, Repo: repo, Storage: &mockStorage{}, Processor: &mockProcessor{}}
+
+	input := model.CreateDocumentInput{
+		DisplayName:     "test.docx",
+		StorageBucketID: uuid.New(),
+		AuthorizationID: uuid.New(),
+		SkipDedup:       true,
+	}
+	_, err := svc.CreateDocument(context.Background(), input, []byte("content"), "", nil, 0)
+	if !errors.Is(err, ErrConflict) {
+		t.Errorf("expected ErrConflict on SkipDedup duplicate-key, got %v", err)
+	}
+}
+
 // mockRepoRace is a minimal repo mock supporting a scripted FindByExternalIDAndBucket
 // and a fixed Create error — used for the concurrent race test.
 type mockRepoRace struct {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -162,6 +162,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/http.errorResponse'
           description: Bad Request
+        "409":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/http.errorResponse'
+          description: Conflict
         "413":
           content:
             application/json: {}


### PR DESCRIPTION
## Background

v0.0.10 introduced per-bucket content-hash dedup on `POST /internal/file`. That's correct for genuine content uploads but breaks the alkem-io/server's Collabora flow: the server creates a `Document` by uploading `Buffer.alloc(0)` to establish identity, and Collabora Online writes the actual content later via WOPI `PutFile`. With dedup on, two empty-buffer creates in the same bucket coalesce to a single backing row, and Collabora editor sessions on the two logical documents corrupt each other.

## What changed

- New multipart form field `skipDedup` (bool, default `false`)
- `model.CreateDocumentInput.SkipDedup` plumbed through
- `CreateDocument` service: when `SkipDedup=true`, bypasses `FindByExternalIDAndBucket` and always inserts a fresh row; always returns `Reused=false`; honors caller-supplied `authorizationId`/`tagsetId` on the new row
- `insertDocument`: if the schema enforces `unique(externalID, storageBucketID)` and the insert conflicts under `SkipDedup`, surfaces `ErrConflict` (HTTP 409) — not a silent dedup hit, which would defeat the purpose

## Backward compatibility

- Field omitted → behaves exactly like v0.0.10 (dedup on)
- Response DTO unchanged: `reused` is already part of the contract; under `skipDedup=true` it always reads `false`
- No DDL changes (the `file` schema lives in alkem-io/server)

## Why explicit, not heuristic

Per task spec: no auto-skip-on-zero-bytes magic. Future placeholder flows reuse the same opt-out, so the API surface is explicit.

## Test plan
- [x] `SkipDedup=true` + existing matching row → fresh row inserted, `Reused=false`, lookup never called, caller's auth/tagset honored
- [x] `SkipDedup=true` + empty content → fresh row (Collabora placeholder path)
- [x] `SkipDedup=false`/omitted → dedup behavior preserved (regression guard)
- [x] `SkipDedup=true` hits unique-key violation → `ErrConflict` (not `Reused=true`)
- [x] HTTP-level: `skipDedup=true` form field bypasses dedup, returns 201
- [x] Malformed `skipDedup` value → 400
- [x] Existing test suite still passes; lint clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional skipDedup parameter to force creation of a new document even when an identical one exists.

* **Improvements**
  * Creation now returns HTTP 409 Conflict when a forced-insert collision occurs instead of a generic error.

* **Documentation**
  * API docs updated to describe the new parameter and 409 response.

* **Tests**
  * Added HTTP- and service-level tests covering skipDedup behavior and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->