### PR TITLE
Add POST /internal/file/copy for cross-bucket document copy

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -71,7 +71,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Install apispec
-        run: go install github.com/antst/go-apispec/cmd/apispec@latest
+        run: go install github.com/antst/go-apispec/cmd/apispec@v0.4.8
 
       - name: Generate OpenAPI spec
         run: make openapi

--- a/internal/adapter/inbound/http/document_handler.go
+++ b/internal/adapter/inbound/http/document_handler.go
@@ -231,6 +231,90 @@ func (h *DocumentHandler) Create(w http.ResponseWriter, r *http.Request) {
 	}.Render(w)
 }
 
+// Copy handles POST /internal/file/copy.
+// Materializes a new file row in another bucket that references the same
+// content as the source. No bytes traverse the wire — content is
+// content-addressed, so the new row simply points at the existing blob.
+//
+// Per-bucket dedup applies by default; SkipDedup=true forces a fresh row.
+// On dedup hit, caller-supplied authorizationId/tagsetId are ignored
+// (existing row is authoritative), matching the createDocument contract.
+func (h *DocumentHandler) Copy(w http.ResponseWriter, r *http.Request) {
+	var body CopyDocumentRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+
+	sourceID, err := uuid.Parse(body.SourceID)
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid sourceId")
+		return
+	}
+	destBucketID, err := uuid.Parse(body.DestinationBucketID)
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid destinationBucketId")
+		return
+	}
+	authID, err := uuid.Parse(body.AuthorizationID)
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid authorizationId")
+		return
+	}
+
+	var tagsetID *uuid.UUID
+	if body.TagsetID != nil && *body.TagsetID != "" {
+		parsed, err := uuid.Parse(*body.TagsetID)
+		if err != nil {
+			writeJSONError(w, http.StatusBadRequest, "invalid tagsetId")
+			return
+		}
+		tagsetID = &parsed
+	}
+
+	var createdBy *uuid.UUID
+	if body.CreatedBy != nil && *body.CreatedBy != "" {
+		parsed, err := uuid.Parse(*body.CreatedBy)
+		if err != nil {
+			writeJSONError(w, http.StatusBadRequest, "invalid createdBy")
+			return
+		}
+		createdBy = &parsed
+	}
+
+	input := model.CopyDocumentInput{
+		DestinationBucketID: destBucketID,
+		AuthorizationID:     authID,
+		TagsetID:            tagsetID,
+		CreatedBy:           createdBy,
+		SkipDedup:           body.SkipDedup,
+	}
+
+	doc, err := h.Service.CopyDocument(r.Context(), sourceID, input)
+	if err != nil {
+		switch {
+		case errors.Is(err, model.ErrDocumentNotFound):
+			writeJSONError(w, http.StatusNotFound, "source document not found")
+		case errors.Is(err, service.ErrConflict):
+			// Reachable only when SkipDedup=true and the destination bucket
+			// already has a row with this content under the unique index.
+			writeJSONError(w, http.StatusConflict, "skipDedup requested but a row with this content already exists in the destination bucket")
+		default:
+			h.Logger.Error("failed to copy document", zap.Error(err))
+			writeJSONError(w, http.StatusInternalServerError, "internal error")
+		}
+		return
+	}
+
+	CreateDocumentResponse{
+		ID:         doc.ID.String(),
+		ExternalID: doc.ExternalID,
+		MimeType:   doc.MimeType,
+		Size:       doc.Size,
+		Reused:     doc.Reused,
+	}.Render(w)
+}
+
 // Delete handles DELETE /internal/document/{id}
 func (h *DocumentHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	docID, err := parseDocID(r)

--- a/internal/adapter/inbound/http/document_handler_test.go
+++ b/internal/adapter/inbound/http/document_handler_test.go
@@ -357,6 +357,193 @@ func TestDocumentHandler_Create_SkipDedup_InvalidValue_400(t *testing.T) {
 	}
 }
 
+// POST /internal/file/copy: happy path. Source exists; copy to a different
+// bucket returns 201 with Reused=false and a fresh ID.
+func TestDocumentHandler_Copy_Success(t *testing.T) {
+	h, repo, _ := newDocHandler()
+	sourceID := uuid.New()
+	repo.doc = model.Document{
+		ID:              sourceID,
+		ExternalID:      "sha3-of-content",
+		MimeType:        "image/png",
+		Size:            42,
+		DisplayName:     "banner.png",
+		StorageBucketID: uuid.New(),
+		AuthorizationID: uuid.New(),
+	}
+
+	body, _ := json.Marshal(CopyDocumentRequest{
+		SourceID:            sourceID.String(),
+		DestinationBucketID: uuid.New().String(),
+		AuthorizationID:     uuid.New().String(),
+	})
+
+	r := chi.NewRouter()
+	r.Post("/internal/file/copy", h.Copy)
+
+	req := httptest.NewRequest(http.MethodPost, "/internal/file/copy", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201, body: %s", rr.Code, rr.Body.String())
+	}
+	var resp map[string]any
+	_ = json.Unmarshal(rr.Body.Bytes(), &resp)
+	if reused, ok := resp["reused"].(bool); !ok || reused {
+		t.Errorf("reused = %v, want false for fresh copy", resp["reused"])
+	}
+	if resp["externalID"] != "sha3-of-content" {
+		t.Errorf("externalID = %v, want preserved from source", resp["externalID"])
+	}
+	if resp["mimeType"] != "image/png" {
+		t.Errorf("mimeType = %v, want preserved from source", resp["mimeType"])
+	}
+}
+
+// POST /internal/file/copy: dedup hit returns 201 + reused=true.
+func TestDocumentHandler_Copy_DedupHit_ReturnsReusedTrue(t *testing.T) {
+	h, repo, _ := newDocHandler()
+	sourceID := uuid.New()
+	bucketB := uuid.New()
+	existingID := uuid.New()
+	repo.doc = model.Document{
+		ID:         sourceID,
+		ExternalID: "sha3-of-content",
+		MimeType:   "image/png",
+		Size:       42,
+	}
+	repo.findDoc = &model.Document{
+		ID:              existingID,
+		ExternalID:      "sha3-of-content",
+		StorageBucketID: bucketB,
+		AuthorizationID: uuid.New(),
+	}
+
+	body, _ := json.Marshal(CopyDocumentRequest{
+		SourceID:            sourceID.String(),
+		DestinationBucketID: bucketB.String(),
+		AuthorizationID:     uuid.New().String(),
+	})
+
+	r := chi.NewRouter()
+	r.Post("/internal/file/copy", h.Copy)
+
+	req := httptest.NewRequest(http.MethodPost, "/internal/file/copy", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201, body: %s", rr.Code, rr.Body.String())
+	}
+	var resp map[string]any
+	_ = json.Unmarshal(rr.Body.Bytes(), &resp)
+	if reused, ok := resp["reused"].(bool); !ok || !reused {
+		t.Errorf("reused = %v, want true on dedup hit", resp["reused"])
+	}
+	if resp["id"] != existingID.String() {
+		t.Errorf("id = %v, want existing %v", resp["id"], existingID.String())
+	}
+}
+
+// POST /internal/file/copy: source not found → 404.
+func TestDocumentHandler_Copy_SourceNotFound_404(t *testing.T) {
+	h, repo, _ := newDocHandler()
+	repo.err = model.ErrDocumentNotFound
+
+	body, _ := json.Marshal(CopyDocumentRequest{
+		SourceID:            uuid.New().String(),
+		DestinationBucketID: uuid.New().String(),
+		AuthorizationID:     uuid.New().String(),
+	})
+
+	r := chi.NewRouter()
+	r.Post("/internal/file/copy", h.Copy)
+
+	req := httptest.NewRequest(http.MethodPost, "/internal/file/copy", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404, body: %s", rr.Code, rr.Body.String())
+	}
+}
+
+// POST /internal/file/copy: invalid sourceId → 400.
+func TestDocumentHandler_Copy_InvalidSourceID_400(t *testing.T) {
+	h, _, _ := newDocHandler()
+
+	body, _ := json.Marshal(CopyDocumentRequest{
+		SourceID:            "not-a-uuid",
+		DestinationBucketID: uuid.New().String(),
+		AuthorizationID:     uuid.New().String(),
+	})
+
+	r := chi.NewRouter()
+	r.Post("/internal/file/copy", h.Copy)
+
+	req := httptest.NewRequest(http.MethodPost, "/internal/file/copy", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", rr.Code)
+	}
+}
+
+// POST /internal/file/copy: malformed JSON body → 400.
+func TestDocumentHandler_Copy_MalformedJSON_400(t *testing.T) {
+	h, _, _ := newDocHandler()
+
+	r := chi.NewRouter()
+	r.Post("/internal/file/copy", h.Copy)
+
+	req := httptest.NewRequest(http.MethodPost, "/internal/file/copy", strings.NewReader("{not-json"))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", rr.Code)
+	}
+}
+
+// POST /internal/file/copy: skipDedup=true + unique-key violation → 409.
+func TestDocumentHandler_Copy_SkipDedup_Conflict_Returns409(t *testing.T) {
+	h, repo, _ := newDocHandler()
+	sourceID := uuid.New()
+	repo.doc = model.Document{
+		ID:         sourceID,
+		ExternalID: "sha3-of-content",
+		MimeType:   "image/png",
+		Size:       42,
+	}
+	repo.createErr = model.ErrDuplicateKey
+
+	body, _ := json.Marshal(CopyDocumentRequest{
+		SourceID:            sourceID.String(),
+		DestinationBucketID: uuid.New().String(),
+		AuthorizationID:     uuid.New().String(),
+		SkipDedup:           true,
+	})
+
+	r := chi.NewRouter()
+	r.Post("/internal/file/copy", h.Copy)
+
+	req := httptest.NewRequest(http.MethodPost, "/internal/file/copy", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409, body: %s", rr.Code, rr.Body.String())
+	}
+}
+
 func TestDocumentHandler_Create_AllFields(t *testing.T) {
 	h, _, _ := newDocHandler()
 

--- a/internal/adapter/inbound/http/dto.go
+++ b/internal/adapter/inbound/http/dto.go
@@ -93,6 +93,17 @@ type UpdateDocumentRequest struct {
 	TemporaryLocation *bool   `json:"temporaryLocation"`
 }
 
+// CopyDocumentRequest is the JSON body for POST /internal/file/copy.
+// Reuses CreateDocumentResponse for the response shape.
+type CopyDocumentRequest struct {
+	SourceID            string  `json:"sourceId"`
+	DestinationBucketID string  `json:"destinationBucketId"`
+	AuthorizationID     string  `json:"authorizationId"`
+	TagsetID            *string `json:"tagsetId,omitempty"`
+	CreatedBy           *string `json:"createdBy,omitempty"`
+	SkipDedup           bool    `json:"skipDedup,omitempty"`
+}
+
 // HealthResponse is returned by GET /health.
 type HealthResponse struct {
 	Status  string            `json:"status"`

--- a/internal/adapter/inbound/http/router.go
+++ b/internal/adapter/inbound/http/router.go
@@ -61,6 +61,7 @@ func NewRouter(deps Deps) *chi.Mux {
 	// Internal endpoints (no auth)
 	r.Route("/internal", func(r chi.Router) {
 		r.Post("/file", deps.DocumentHandler.Create)
+		r.Post("/file/copy", deps.DocumentHandler.Copy)
 		r.Get("/file/{id}/meta", deps.DocumentHandler.GetMeta)
 		r.Get("/file/{id}/content", deps.DocumentHandler.GetContent)
 		r.Put("/file/{id}/content", deps.DocumentHandler.ReplaceContent)

--- a/internal/domain/model/document.go
+++ b/internal/domain/model/document.go
@@ -47,6 +47,21 @@ type CreateDocumentInput struct {
 	SkipDedup bool
 }
 
+// CopyDocumentInput contains fields needed to copy an existing document into
+// another bucket. The new row references the same content (same externalID,
+// mimeType, size, displayName) as the source; only ownership/placement
+// changes. The source row is not modified.
+type CopyDocumentInput struct {
+	DestinationBucketID uuid.UUID
+	AuthorizationID     uuid.UUID
+	TagsetID            *uuid.UUID
+	CreatedBy           *uuid.UUID
+
+	// SkipDedup mirrors the same flag on CreateDocumentInput. Default false
+	// runs the per-bucket dedup lookup; true forces a fresh row insert.
+	SkipDedup bool
+}
+
 // StoredFile represents the result of a file storage operation.
 type StoredFile struct {
 	ExternalID string

--- a/internal/domain/service/file_service.go
+++ b/internal/domain/service/file_service.go
@@ -141,7 +141,7 @@ func (s *FileService) CopyDocument(ctx context.Context, sourceID uuid.UUID, inpu
 	createInput := model.CreateDocumentInput{
 		DisplayName:       source.DisplayName,
 		CreatedBy:         input.CreatedBy,
-		TemporaryLocation: false, // copies are deliberate placements
+		TemporaryLocation: false,
 		StorageBucketID:   input.DestinationBucketID,
 		AuthorizationID:   input.AuthorizationID,
 		TagsetID:          input.TagsetID,
@@ -151,7 +151,6 @@ func (s *FileService) CopyDocument(ctx context.Context, sourceID uuid.UUID, inpu
 		ExternalID: source.ExternalID,
 		MimeType:   source.MimeType,
 		Size:       source.Size,
-		// Created intentionally false: no blob was written by this request.
 	}
 	return s.insertDocument(ctx, createInput, stored, source.MimeType)
 }

--- a/internal/domain/service/file_service.go
+++ b/internal/domain/service/file_service.go
@@ -109,6 +109,53 @@ func (s *FileService) CreateDocument(ctx context.Context, input model.CreateDocu
 	return s.insertDocument(ctx, input, stored, finalMIME)
 }
 
+// CopyDocument creates a new file row in another bucket that references the
+// same content as an existing source row. No bytes are moved or re-uploaded:
+// content is content-addressed by hash, so two rows in different buckets
+// can share underlying storage. The source row is not modified.
+//
+// Per-bucket dedup applies by default (skip with SkipDedup): if the
+// destination bucket already has a row with the same externalID, return
+// it as-is with Reused=true, matching the CreateDocument contract.
+func (s *FileService) CopyDocument(ctx context.Context, sourceID uuid.UUID, input model.CopyDocumentInput) (*model.Document, error) {
+	source, err := s.Repo.GetByID(ctx, sourceID)
+	if err != nil {
+		// ErrDocumentNotFound surfaces as 404 in the handler.
+		return nil, err
+	}
+
+	if !input.SkipDedup {
+		existing, err := s.Repo.FindByExternalIDAndBucket(ctx, source.ExternalID, input.DestinationBucketID)
+		if err != nil && !errors.Is(err, model.ErrDocumentNotFound) {
+			return nil, fmt.Errorf("dedup lookup: %w", err)
+		}
+		if err == nil {
+			existing.Reused = true
+			return &existing, nil
+		}
+	}
+
+	// Reuse insertDocument so race-handling, error mapping (ErrDuplicateKey →
+	// ErrConflict on SkipDedup, race re-query otherwise), and audit fields
+	// stay identical to CreateDocument.
+	createInput := model.CreateDocumentInput{
+		DisplayName:       source.DisplayName,
+		CreatedBy:         input.CreatedBy,
+		TemporaryLocation: false, // copies are deliberate placements
+		StorageBucketID:   input.DestinationBucketID,
+		AuthorizationID:   input.AuthorizationID,
+		TagsetID:          input.TagsetID,
+		SkipDedup:         input.SkipDedup,
+	}
+	stored := model.StoredFile{
+		ExternalID: source.ExternalID,
+		MimeType:   source.MimeType,
+		Size:       source.Size,
+		// Created intentionally false: no blob was written by this request.
+	}
+	return s.insertDocument(ctx, createInput, stored, source.MimeType)
+}
+
 // resolveMIME determines the effective MIME type and validates it against the allow-list.
 // Empty content: trust declaredMIME (no bytes to detect from).
 // Non-empty: detect from content bytes.

--- a/internal/domain/service/file_service.go
+++ b/internal/domain/service/file_service.go
@@ -93,20 +93,34 @@ func (s *FileService) CreateDocument(ctx context.Context, input model.CreateDocu
 	// return it as-is. The caller-supplied AuthorizationID / TagsetID are ignored —
 	// the existing row's values are authoritative. Caller must use Reused=true to
 	// clean up the auth/tagset rows it pre-created.
-	existing, err := s.Repo.FindByExternalIDAndBucket(ctx, stored.ExternalID, input.StorageBucketID)
-	if err != nil && !errors.Is(err, model.ErrDocumentNotFound) {
-		// Lookup failed for a reason we can't diagnose (DB hiccup).
-		// Another row may already reference this blob — deleting it would
-		// orphan that row, which is worse than orphaning a blob (blobs are
-		// GC-able by a periodic sweep). Leave the blob in place.
-		return nil, fmt.Errorf("dedup lookup: %w", err)
+	//
+	// Lookup failure (non-not-found): another row may already reference this
+	// blob — deleting it would orphan that row, which is worse than orphaning
+	// a blob (blobs are GC-able). Leave the blob in place.
+	existing, found, err := s.findDedupDocument(ctx, stored.ExternalID, input.StorageBucketID)
+	if err != nil {
+		return nil, err
 	}
-	if err == nil {
+	if found {
 		existing.Reused = true
-		return &existing, nil
+		return existing, nil
 	}
 
 	return s.insertDocument(ctx, input, stored, finalMIME)
+}
+
+// findDedupDocument looks up an existing file row for (externalID, bucketID).
+// Returns (doc, true, nil) on hit, (nil, false, nil) when no row exists, and
+// (nil, false, err) on lookup failure.
+func (s *FileService) findDedupDocument(ctx context.Context, externalID string, bucketID uuid.UUID) (*model.Document, bool, error) {
+	existing, err := s.Repo.FindByExternalIDAndBucket(ctx, externalID, bucketID)
+	if err != nil {
+		if errors.Is(err, model.ErrDocumentNotFound) {
+			return nil, false, nil
+		}
+		return nil, false, fmt.Errorf("dedup lookup: %w", err)
+	}
+	return &existing, true, nil
 }
 
 // CopyDocument creates a new file row in another bucket that references the
@@ -125,13 +139,13 @@ func (s *FileService) CopyDocument(ctx context.Context, sourceID uuid.UUID, inpu
 	}
 
 	if !input.SkipDedup {
-		existing, err := s.Repo.FindByExternalIDAndBucket(ctx, source.ExternalID, input.DestinationBucketID)
-		if err != nil && !errors.Is(err, model.ErrDocumentNotFound) {
-			return nil, fmt.Errorf("dedup lookup: %w", err)
+		existing, found, err := s.findDedupDocument(ctx, source.ExternalID, input.DestinationBucketID)
+		if err != nil {
+			return nil, err
 		}
-		if err == nil {
+		if found {
 			existing.Reused = true
-			return &existing, nil
+			return existing, nil
 		}
 	}
 

--- a/internal/domain/service/file_service_test.go
+++ b/internal/domain/service/file_service_test.go
@@ -550,6 +550,220 @@ func TestCreateDocument_DBFails_DoesNotDeleteBlob(t *testing.T) {
 	}
 }
 
+// CopyDocument: happy path. Source exists in bucket A; copy to bucket B
+// produces a fresh row with same content metadata, caller's auth/tagset.
+func TestCopyDocument_Happy(t *testing.T) {
+	sourceID := uuid.New()
+	bucketA := uuid.New()
+	bucketB := uuid.New()
+	source := model.Document{
+		ID:              sourceID,
+		ExternalID:      "sha3-of-content",
+		MimeType:        "image/png",
+		Size:            42,
+		DisplayName:     "banner.png",
+		StorageBucketID: bucketA,
+		AuthorizationID: uuid.New(),
+	}
+	repo := &mockRepo{doc: source}
+	svc := &FileService{Logger: nopLogger, Repo: repo, Storage: &mockStorage{}, Processor: &mockProcessor{}}
+
+	callerAuth := uuid.New()
+	callerTagset := uuid.New()
+	doc, err := svc.CopyDocument(context.Background(), sourceID, model.CopyDocumentInput{
+		DestinationBucketID: bucketB,
+		AuthorizationID:     callerAuth,
+		TagsetID:            &callerTagset,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if doc.Reused {
+		t.Error("expected Reused=false for fresh copy")
+	}
+	if doc.ID == sourceID {
+		t.Error("copy must have a fresh ID, got source ID")
+	}
+	if doc.ExternalID != source.ExternalID {
+		t.Errorf("ExternalID = %q, want %q (content preserved)", doc.ExternalID, source.ExternalID)
+	}
+	if doc.MimeType != source.MimeType {
+		t.Errorf("MimeType = %q, want %q", doc.MimeType, source.MimeType)
+	}
+	if doc.Size != source.Size {
+		t.Errorf("Size = %d, want %d", doc.Size, source.Size)
+	}
+	if doc.DisplayName != source.DisplayName {
+		t.Errorf("DisplayName = %q, want %q", doc.DisplayName, source.DisplayName)
+	}
+	if doc.StorageBucketID != bucketB {
+		t.Errorf("StorageBucketID = %v, want destination %v", doc.StorageBucketID, bucketB)
+	}
+	if doc.AuthorizationID != callerAuth {
+		t.Errorf("AuthorizationID = %v, want caller's %v", doc.AuthorizationID, callerAuth)
+	}
+	if doc.TagsetID == nil || *doc.TagsetID != callerTagset {
+		t.Errorf("TagsetID = %v, want caller's %v", doc.TagsetID, callerTagset)
+	}
+	if doc.TemporaryLocation {
+		t.Error("copies are deliberate placements; TemporaryLocation must be false")
+	}
+}
+
+// CopyDocument: dedup hit. Destination bucket already has a row with
+// this content → returns existing row with Reused=true; caller-supplied
+// auth/tagset are NOT applied (regression guard for the reused contract).
+func TestCopyDocument_DedupHit_ReturnsExistingReused(t *testing.T) {
+	sourceID := uuid.New()
+	bucketB := uuid.New()
+	existingID := uuid.New()
+	existingAuth := uuid.New()
+	repo := &mockRepo{
+		doc: model.Document{
+			ID:         sourceID,
+			ExternalID: "sha3-of-content",
+			MimeType:   "image/png",
+			Size:       42,
+		},
+		findDoc: &model.Document{
+			ID:              existingID,
+			ExternalID:      "sha3-of-content",
+			StorageBucketID: bucketB,
+			AuthorizationID: existingAuth,
+		},
+	}
+	svc := &FileService{Logger: nopLogger, Repo: repo, Storage: &mockStorage{}, Processor: &mockProcessor{}}
+
+	callerAuth := uuid.New() // should be ignored on dedup hit
+	doc, err := svc.CopyDocument(context.Background(), sourceID, model.CopyDocumentInput{
+		DestinationBucketID: bucketB,
+		AuthorizationID:     callerAuth,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !doc.Reused {
+		t.Error("expected Reused=true on dedup hit")
+	}
+	if doc.ID != existingID {
+		t.Errorf("ID = %v, want existing %v", doc.ID, existingID)
+	}
+	if doc.AuthorizationID != existingAuth {
+		t.Errorf("AuthorizationID = %v, want existing %v (caller's must be ignored)", doc.AuthorizationID, existingAuth)
+	}
+	if repo.createCalls != 0 {
+		t.Errorf("expected 0 Create calls on dedup hit, got %d", repo.createCalls)
+	}
+}
+
+// CopyDocument with SkipDedup=true forces a fresh row even when an
+// existing row matches. Dedup lookup must NOT be called.
+func TestCopyDocument_SkipDedup_BypassesDedup(t *testing.T) {
+	sourceID := uuid.New()
+	bucketB := uuid.New()
+	repo := &mockRepo{
+		doc: model.Document{
+			ID:         sourceID,
+			ExternalID: "sha3-of-content",
+			MimeType:   "image/png",
+			Size:       42,
+		},
+		// findDoc set to prove we never call FindByExternalIDAndBucket.
+		findDoc: &model.Document{
+			ID:              uuid.New(),
+			StorageBucketID: bucketB,
+			AuthorizationID: uuid.New(),
+		},
+	}
+	svc := &FileService{Logger: nopLogger, Repo: repo, Storage: &mockStorage{}, Processor: &mockProcessor{}}
+
+	doc, err := svc.CopyDocument(context.Background(), sourceID, model.CopyDocumentInput{
+		DestinationBucketID: bucketB,
+		AuthorizationID:     uuid.New(),
+		SkipDedup:           true,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if doc.Reused {
+		t.Error("expected Reused=false when SkipDedup=true")
+	}
+	if repo.findCalls != 0 {
+		t.Errorf("expected 0 FindByExternalIDAndBucket calls, got %d", repo.findCalls)
+	}
+	if repo.createCalls != 1 {
+		t.Errorf("expected 1 Create call, got %d", repo.createCalls)
+	}
+}
+
+// CopyDocument when source doesn't exist surfaces ErrDocumentNotFound
+// (handler maps to 404).
+func TestCopyDocument_SourceNotFound(t *testing.T) {
+	repo := &mockRepo{getErr: model.ErrDocumentNotFound}
+	svc := &FileService{Logger: nopLogger, Repo: repo, Storage: &mockStorage{}, Processor: &mockProcessor{}}
+
+	_, err := svc.CopyDocument(context.Background(), uuid.New(), model.CopyDocumentInput{
+		DestinationBucketID: uuid.New(),
+		AuthorizationID:     uuid.New(),
+	})
+	if !errors.Is(err, model.ErrDocumentNotFound) {
+		t.Errorf("expected ErrDocumentNotFound, got %v", err)
+	}
+}
+
+// CopyDocument with SkipDedup=true and a unique-key violation surfaces
+// ErrConflict (handler maps to 409). Mirrors CreateDocument's behavior.
+func TestCopyDocument_SkipDedup_DuplicateKey_ReturnsConflict(t *testing.T) {
+	sourceID := uuid.New()
+	source := model.Document{ID: sourceID, ExternalID: "sha3-of-content", MimeType: "image/png", Size: 42}
+
+	// Use mockRepoRace to script the create behavior (ErrDuplicateKey).
+	// GetByID returns the source; find must not be called when SkipDedup=true.
+	repo := &copyRaceRepo{source: source, createErr: model.ErrDuplicateKey}
+	svc := &FileService{Logger: nopLogger, Repo: repo, Storage: &mockStorage{}, Processor: &mockProcessor{}}
+
+	_, err := svc.CopyDocument(context.Background(), sourceID, model.CopyDocumentInput{
+		DestinationBucketID: uuid.New(),
+		AuthorizationID:     uuid.New(),
+		SkipDedup:           true,
+	})
+	if !errors.Is(err, ErrConflict) {
+		t.Errorf("expected ErrConflict on SkipDedup duplicate-key, got %v", err)
+	}
+}
+
+// copyRaceRepo: minimal mock for CopyDocument duplicate-key tests.
+// Returns source on GetByID, errors on Find (must not be called when
+// SkipDedup=true), and a fixed Create error.
+type copyRaceRepo struct {
+	source    model.Document
+	createErr error
+}
+
+var _ port.DocumentRepo = (*copyRaceRepo)(nil)
+
+func (m *copyRaceRepo) GetByID(_ context.Context, _ uuid.UUID) (model.Document, error) {
+	return m.source, nil
+}
+func (m *copyRaceRepo) FindByExternalIDAndBucket(_ context.Context, _ string, _ uuid.UUID) (model.Document, error) {
+	return model.Document{}, model.ErrDocumentNotFound
+}
+func (m *copyRaceRepo) Create(_ context.Context, _ model.Document) (uuid.UUID, error) {
+	return uuid.Nil, m.createErr
+}
+func (m *copyRaceRepo) UpdateFile(_ context.Context, _ uuid.UUID, _, _ string, _ int) error {
+	return nil
+}
+func (m *copyRaceRepo) UpdateLocation(_ context.Context, _ uuid.UUID, _ uuid.UUID, _ bool, _ int) error {
+	return nil
+}
+func (m *copyRaceRepo) Delete(_ context.Context, _ uuid.UUID) (model.DeletedDocument, error) {
+	return model.DeletedDocument{}, nil
+}
+func (m *copyRaceRepo) CountByExternalID(_ context.Context, _ string) (int, error) {
+	return 0, nil
+}
+
 func TestDeleteDocument_UniqueFile_DeletesFromStorage(t *testing.T) {
 	authID := uuid.New()
 	storage := &mockStorage{}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -161,50 +161,13 @@ paths:
       operationId: DocumentHandler.Create
       parameters:
         - in: form
-          name: file
-          schema:
-            format: binary
-            type: string
-        - in: form
-          name: displayName
-          schema:
-            type: string
-        - in: form
           name: storageBucketId
           schema:
-            format: uuid
             type: string
         - in: form
           name: authorizationId
           schema:
-            format: uuid
             type: string
-        - in: form
-          name: tagsetId
-          schema:
-            format: uuid
-            type: string
-        - in: form
-          name: createdBy
-          schema:
-            format: uuid
-            type: string
-        - in: form
-          name: temporaryLocation
-          schema:
-            type: boolean
-        - in: form
-          name: skipDedup
-          schema:
-            type: boolean
-        - in: form
-          name: allowedMimeTypes
-          schema:
-            type: integer
-        - in: form
-          name: maxFileSize
-          schema:
-            type: integer
       responses:
         "201":
           content:
@@ -297,7 +260,6 @@ paths:
           name: id
           required: true
           schema:
-            format: uuid
             type: string
       responses:
         "200":
@@ -327,7 +289,6 @@ paths:
           name: id
           required: true
           schema:
-            format: uuid
             type: string
       requestBody:
         content:
@@ -373,7 +334,6 @@ paths:
           name: id
           required: true
           schema:
-            format: uuid
             type: string
       responses:
         "200":
@@ -404,7 +364,6 @@ paths:
           name: id
           required: true
           schema:
-            format: uuid
             type: string
       responses:
         "200":
@@ -457,7 +416,6 @@ paths:
           name: id
           required: true
           schema:
-            format: uuid
             type: string
       responses:
         "200":
@@ -501,7 +459,6 @@ paths:
           name: id
           required: true
           schema:
-            format: uuid
             type: string
       responses:
         "200":

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -161,13 +161,50 @@ paths:
       operationId: DocumentHandler.Create
       parameters:
         - in: form
+          name: file
+          schema:
+            format: binary
+            type: string
+        - in: form
+          name: displayName
+          schema:
+            type: string
+        - in: form
           name: storageBucketId
           schema:
+            format: uuid
             type: string
         - in: form
           name: authorizationId
           schema:
+            format: uuid
             type: string
+        - in: form
+          name: tagsetId
+          schema:
+            format: uuid
+            type: string
+        - in: form
+          name: createdBy
+          schema:
+            format: uuid
+            type: string
+        - in: form
+          name: temporaryLocation
+          schema:
+            type: boolean
+        - in: form
+          name: skipDedup
+          schema:
+            type: boolean
+        - in: form
+          name: allowedMimeTypes
+          schema:
+            type: string
+        - in: form
+          name: maxFileSize
+          schema:
+            type: integer
       responses:
         "201":
           content:
@@ -260,6 +297,7 @@ paths:
           name: id
           required: true
           schema:
+            format: uuid
             type: string
       responses:
         "200":
@@ -289,6 +327,7 @@ paths:
           name: id
           required: true
           schema:
+            format: uuid
             type: string
       requestBody:
         content:
@@ -334,6 +373,7 @@ paths:
           name: id
           required: true
           schema:
+            format: uuid
             type: string
       responses:
         "200":
@@ -364,6 +404,7 @@ paths:
           name: id
           required: true
           schema:
+            format: uuid
             type: string
       responses:
         "200":
@@ -416,6 +457,7 @@ paths:
           name: id
           required: true
           schema:
+            format: uuid
             type: string
       responses:
         "200":
@@ -459,6 +501,7 @@ paths:
           name: id
           required: true
           schema:
+            format: uuid
             type: string
       responses:
         "200":

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,5 +1,24 @@
 components:
   schemas:
+    http.CopyDocumentRequest:
+      properties:
+        authorizationId:
+          type: string
+        createdBy:
+          type: string
+        destinationBucketId:
+          type: string
+        skipDedup:
+          type: boolean
+        sourceId:
+          type: string
+        tagsetId:
+          type: string
+      required:
+        - sourceId
+        - destinationBucketId
+        - authorizationId
+      type: object
     http.CreateDocumentResponse:
       properties:
         externalID:
@@ -142,13 +161,50 @@ paths:
       operationId: DocumentHandler.Create
       parameters:
         - in: form
+          name: file
+          schema:
+            format: binary
+            type: string
+        - in: form
+          name: displayName
+          schema:
+            type: string
+        - in: form
           name: storageBucketId
           schema:
+            format: uuid
             type: string
         - in: form
           name: authorizationId
           schema:
+            format: uuid
             type: string
+        - in: form
+          name: tagsetId
+          schema:
+            format: uuid
+            type: string
+        - in: form
+          name: createdBy
+          schema:
+            format: uuid
+            type: string
+        - in: form
+          name: temporaryLocation
+          schema:
+            type: boolean
+        - in: form
+          name: skipDedup
+          schema:
+            type: boolean
+        - in: form
+          name: allowedMimeTypes
+          schema:
+            type: integer
+        - in: form
+          name: maxFileSize
+          schema:
+            type: integer
       responses:
         "201":
           content:
@@ -192,6 +248,47 @@ paths:
           description: Internal Server Error
       tags:
         - /internal
+  /internal/file/copy:
+    post:
+      operationId: DocumentHandler.Copy
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/http.CopyDocumentRequest'
+      responses:
+        "201":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/http.CreateDocumentResponse'
+          description: Created
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/http.errorResponse'
+          description: Bad Request
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/http.errorResponse'
+          description: Not Found
+        "409":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/http.errorResponse'
+          description: Conflict
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/http.errorResponse'
+          description: Internal Server Error
+      tags:
+        - /internal
   /internal/file/{id}:
     delete:
       operationId: DocumentHandler.Delete
@@ -200,6 +297,7 @@ paths:
           name: id
           required: true
           schema:
+            format: uuid
             type: string
       responses:
         "200":
@@ -229,6 +327,7 @@ paths:
           name: id
           required: true
           schema:
+            format: uuid
             type: string
       requestBody:
         content:
@@ -274,6 +373,7 @@ paths:
           name: id
           required: true
           schema:
+            format: uuid
             type: string
       responses:
         "200":
@@ -304,6 +404,7 @@ paths:
           name: id
           required: true
           schema:
+            format: uuid
             type: string
       responses:
         "200":
@@ -356,6 +457,7 @@ paths:
           name: id
           required: true
           schema:
+            format: uuid
             type: string
       responses:
         "200":
@@ -399,6 +501,7 @@ paths:
           name: id
           required: true
           schema:
+            format: uuid
             type: string
       responses:
         "200":


### PR DESCRIPTION
## Background

The alkem-io server has flows (Space-from-Template, markdown re-homing) that need to materialize a new \`file\` row in bucket B with the same content as an existing row in bucket A. Today it fakes this by:

1. \`GET /internal/file/{id}/content\` to pull the bytes
2. \`POST /internal/file\` to push them back

That round-trips the full payload through the server pod for no reason. file-service-go is content-addressed — identical bytes already share underlying storage. \"Copy\" is operationally just \"new row, fresh id, new bucket/auth/tagset, pointing at the same content.\" No blob movement.

This is one piece of the larger fix for [server #6004 / #6005](https://github.com/alkem-io/server/issues/6004).

## Endpoint

**\`POST /internal/file/copy\`**

JSON body:
\`\`\`json
{
  \"sourceId\": \"uuid\",
  \"destinationBucketId\": \"uuid\",
  \"authorizationId\": \"uuid\",
  \"tagsetId\": \"uuid\",       // optional
  \"createdBy\": \"uuid\",      // optional
  \"skipDedup\": false        // optional
}
\`\`\`

Response: existing \`CreateDocumentResponse\` shape (id, externalID, mimeType, size, reused). Status: **201 Created** on both fresh and dedup-hit (uniform POST status), distinguished by \`reused\` field.

## Behavior

- \`displayName\`/\`mimeType\`/\`size\`/\`externalID\` copied verbatim from source. Caller supplies new \`storageBucketId\`/\`authorizationId\`/\`tagsetId\`/\`createdBy\`.
- \`temporaryLocation\` is always \`false\` on copy (deliberate placement).
- Per-bucket dedup applies by default. On dedup hit, caller-supplied auth/tagset are ignored (existing row authoritative — same contract as \`createDocument\`).
- \`skipDedup=true\` bypasses the lookup. If the schema enforces \`unique(externalID, storageBucketID)\`, an insert collision returns **409 Conflict** rather than masquerading as \`reused: true\` — same defensive behavior as \`createDocument\`'s skipDedup path.
- Source row is never mutated. No ref-count changes.
- No bytes are read or written. The endpoint never touches the storage adapter.

## Error matrix

| Condition | Status |
|---|---|
| Malformed JSON / invalid UUID in sourceId/destinationBucketId/authorizationId/tagsetId/createdBy | 400 |
| sourceId not found | 404 |
| skipDedup=true + unique-key violation | 409 |
| Internal failure | 500 |

## Out of scope (per spec)

- No batch endpoint
- No displayName/mimeType override
- No allowed-mime-types re-check
- No content streaming

## Test plan
- [x] Service: happy path; dedup hit (reused contract); skipDedup bypasses lookup; source not found; skipDedup conflict.
- [x] HTTP: 201 happy; 201 dedup-reused; 404 source not found; 400 invalid UUIDs; 400 malformed JSON; 409 skipDedup conflict.
- [x] Existing test suite still passes; lint clean.
- [x] OpenAPI regenerated (clean operation entry: \`DocumentHandler.Copy\`, request body schema \`http.CopyDocumentRequest\`, all error responses).

## After landing

- Tag \`v0.0.14\`.
- Server-side \`FileServiceAdapter.copyDocument\` will replace the bytes-round-trip path in \`ProfileDocumentsService.reuploadFileOnStorageBucket\`'s cross-bucket branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an internal endpoint to copy documents into another bucket without re-uploading content; responses include preserved content metadata and a reused flag for dedup hits.

* **New Options**
  * Optional skip-dedup mode to force creation even when a matching destination exists (may return conflict on unique-key collision).

* **Tests**
  * Added HTTP and unit tests for success, dedup hits, skip-dedup, validation, not-found, conflict, and error mappings.

* **Documentation**
  * API spec updated with request/response schemas and documented error responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->