### PR TITLE
Pin go-apispec to v0.4.9

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -71,7 +71,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Install apispec
-        run: go install github.com/antst/go-apispec/cmd/apispec@v0.4.8
+        run: go install github.com/antst/go-apispec/cmd/apispec@v0.4.9
 
       - name: Generate OpenAPI spec
         run: make openapi

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3,16 +3,21 @@ components:
     http.CopyDocumentRequest:
       properties:
         authorizationId:
+          format: uuid
           type: string
         createdBy:
+          format: uuid
           type: string
         destinationBucketId:
+          format: uuid
           type: string
         skipDedup:
           type: boolean
         sourceId:
+          format: uuid
           type: string
         tagsetId:
+          format: uuid
           type: string
       required:
         - sourceId
@@ -110,6 +115,7 @@ components:
     http.UpdateDocumentRequest:
       properties:
         storageBucketId:
+          format: uuid
           type: string
         temporaryLocation:
           type: boolean
@@ -256,6 +262,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/http.CopyDocumentRequest'
+        required: true
       responses:
         "201":
           content:
@@ -334,6 +341,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/http.UpdateDocumentRequest'
+        required: true
       responses:
         "200":
           content:


### PR DESCRIPTION
## Summary
v0.4.9 closes the two JSON-DTO inference gaps that were the only remaining issues after v0.4.8:

- **\`format: uuid\` on JSON DTO fields** — propagated from handler-level \`uuid.Parse\` calls back to the struct fields they validate
- **\`requestBody.required: true\`** — inferred for any handler that reads its body via \`json.NewDecoder(r.Body).Decode\` and 400s on empty body

## Effect on \`openapi.yaml\`
- \`CopyDocumentRequest\`: \`format: uuid\` on all 5 UUID fields
- \`UpdateDocumentRequest\`: \`format: uuid\` on \`storageBucketId\`
- \`POST /internal/file/copy\` and \`PATCH /internal/file/{id}\` request bodies marked \`required: true\`

## Test plan
- [x] Output is deterministic
- [x] Diff is purely additive (8 lines added, 0 removed); no regressions
- [x] All tests pass; lint clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced API validation with UUID format enforcement for identifier fields in copy and update operations, improving data quality and preventing invalid identifiers from being accepted into the system
* Request bodies are now mandatory for file copy and update endpoints, ensuring all API calls include complete payload information and preventing incomplete submissions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->