### PR TITLE
Permit anonymous reads on public file-serve endpoint

### DIFF
--- a/internal/adapter/inbound/http/document_handler_test.go
+++ b/internal/adapter/inbound/http/document_handler_test.go
@@ -1259,9 +1259,11 @@ func TestPublicHandler_InvalidUUID(t *testing.T) {
 // authorization policy. With a deny-by-default mock, anonymous gets 403
 // — not 401 from the handler.
 func TestPublicHandler_AnonymousRequest_DeniedByPolicy_403(t *testing.T) {
+	policyID := uuid.New()
+	auth := &mockAuth{} // Allowed: false, no error
 	h := &PublicHandler{
-		Repo:    &mockDocRepo{doc: model.Document{ID: uuid.New()}},
-		Auth:    &mockAuth{}, // Allowed: false, no error
+		Repo:    &mockDocRepo{doc: model.Document{ID: uuid.New(), AuthorizationID: policyID}},
+		Auth:    auth,
 		Storage: &mockStorage{},
 		MaxAge:  86400,
 		Logger:  zap.NewNop(),
@@ -1278,18 +1280,33 @@ func TestPublicHandler_AnonymousRequest_DeniedByPolicy_403(t *testing.T) {
 	if rr.Code != http.StatusForbidden {
 		t.Fatalf("status = %d, want 403 (policy denies anonymous)", rr.Code)
 	}
+	if auth.calls != 1 {
+		t.Fatalf("auth-eval called %d times, want exactly 1 (anonymous must reach the policy decision point)", auth.calls)
+	}
+	if auth.lastActorID != "" {
+		t.Errorf("auth received actorID = %q, want empty (anonymous)", auth.lastActorID)
+	}
+	if auth.lastPrivilege != "read" {
+		t.Errorf("auth received privilege = %q, want %q", auth.lastPrivilege, "read")
+	}
+	if auth.lastAuthPolicyID != policyID.String() {
+		t.Errorf("auth received policy = %q, want %q", auth.lastAuthPolicyID, policyID.String())
+	}
 }
 
 // Anonymous request hits a public-bucket document whose policy grants
 // global-anonymous: read. Auth port allows; handler must serve the file.
 func TestPublicHandler_AnonymousRequest_AllowedByPolicy_200(t *testing.T) {
+	policyID := uuid.New()
+	auth := &mockAuth{result: model.AuthResult{Allowed: true}}
 	h := &PublicHandler{
 		Repo: &mockDocRepo{doc: model.Document{
-			ID:         uuid.New(),
-			ExternalID: "abc",
-			MimeType:   "image/png",
+			ID:              uuid.New(),
+			ExternalID:      "abc",
+			MimeType:        "image/png",
+			AuthorizationID: policyID,
 		}},
-		Auth:    &mockAuth{result: model.AuthResult{Allowed: true}},
+		Auth:    auth,
 		Storage: &mockStorage{data: []byte("png-bytes")},
 		MaxAge:  86400,
 		Logger:  zap.NewNop(),
@@ -1308,6 +1325,12 @@ func TestPublicHandler_AnonymousRequest_AllowedByPolicy_200(t *testing.T) {
 	}
 	if rr.Body.String() != "png-bytes" {
 		t.Errorf("body = %q, want file content", rr.Body.String())
+	}
+	if auth.lastActorID != "" {
+		t.Errorf("auth received actorID = %q, want empty (anonymous)", auth.lastActorID)
+	}
+	if auth.lastAuthPolicyID != policyID.String() {
+		t.Errorf("auth received policy = %q, want %q", auth.lastAuthPolicyID, policyID.String())
 	}
 }
 

--- a/internal/adapter/inbound/http/document_handler_test.go
+++ b/internal/adapter/inbound/http/document_handler_test.go
@@ -1326,8 +1326,14 @@ func TestPublicHandler_AnonymousRequest_AllowedByPolicy_200(t *testing.T) {
 	if rr.Body.String() != "png-bytes" {
 		t.Errorf("body = %q, want file content", rr.Body.String())
 	}
+	if auth.calls != 1 {
+		t.Fatalf("auth-eval called %d times, want exactly 1", auth.calls)
+	}
 	if auth.lastActorID != "" {
 		t.Errorf("auth received actorID = %q, want empty (anonymous)", auth.lastActorID)
+	}
+	if auth.lastPrivilege != "read" {
+		t.Errorf("auth received privilege = %q, want %q", auth.lastPrivilege, "read")
 	}
 	if auth.lastAuthPolicyID != policyID.String() {
 		t.Errorf("auth received policy = %q, want %q", auth.lastAuthPolicyID, policyID.String())

--- a/internal/adapter/inbound/http/document_handler_test.go
+++ b/internal/adapter/inbound/http/document_handler_test.go
@@ -1254,10 +1254,14 @@ func TestPublicHandler_InvalidUUID(t *testing.T) {
 	}
 }
 
-func TestPublicHandler_MissingActorID(t *testing.T) {
+// Anonymous request (no actorID in context) reaches the auth-evaluation
+// service. The auth port decides the outcome based on the document's
+// authorization policy. With a deny-by-default mock, anonymous gets 403
+// — not 401 from the handler.
+func TestPublicHandler_AnonymousRequest_DeniedByPolicy_403(t *testing.T) {
 	h := &PublicHandler{
 		Repo:    &mockDocRepo{doc: model.Document{ID: uuid.New()}},
-		Auth:    &mockAuth{},
+		Auth:    &mockAuth{}, // Allowed: false, no error
 		Storage: &mockStorage{},
 		MaxAge:  86400,
 		Logger:  zap.NewNop(),
@@ -1267,12 +1271,43 @@ func TestPublicHandler_MissingActorID(t *testing.T) {
 	r.Get("/rest/storage/document/{id}", h.ServeDocument)
 
 	req := httptest.NewRequest(http.MethodGet, "/rest/storage/document/"+uuid.New().String(), nil)
-	// no actorID in context
+	// no actorID in context — anonymous
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
 
-	if rr.Code != http.StatusUnauthorized {
-		t.Fatalf("status = %d, want 401 for missing actorID", rr.Code)
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403 (policy denies anonymous)", rr.Code)
+	}
+}
+
+// Anonymous request hits a public-bucket document whose policy grants
+// global-anonymous: read. Auth port allows; handler must serve the file.
+func TestPublicHandler_AnonymousRequest_AllowedByPolicy_200(t *testing.T) {
+	h := &PublicHandler{
+		Repo: &mockDocRepo{doc: model.Document{
+			ID:         uuid.New(),
+			ExternalID: "abc",
+			MimeType:   "image/png",
+		}},
+		Auth:    &mockAuth{result: model.AuthResult{Allowed: true}},
+		Storage: &mockStorage{data: []byte("png-bytes")},
+		MaxAge:  86400,
+		Logger:  zap.NewNop(),
+	}
+
+	r := chi.NewRouter()
+	r.Get("/rest/storage/document/{id}", h.ServeDocument)
+
+	req := httptest.NewRequest(http.MethodGet, "/rest/storage/document/"+uuid.New().String(), nil)
+	// no actorID in context — anonymous
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (anonymous read allowed)", rr.Code)
+	}
+	if rr.Body.String() != "png-bytes" {
+		t.Errorf("body = %q, want file content", rr.Body.String())
 	}
 }
 

--- a/internal/adapter/inbound/http/middleware.go
+++ b/internal/adapter/inbound/http/middleware.go
@@ -47,42 +47,48 @@ func GetActorID(ctx context.Context) string {
 
 // JWTExtractor extracts the alkemio_actor_id claim from the Oathkeeper-injected JWT.
 // Oathkeeper has already validated the token; we just decode the payload.
+//
+// Permissive by design: never 401s. Anonymous requests (no Authorization
+// header, missing claim, even malformed token) flow through with an empty
+// actorID. Authorization decisions belong to the auth-evaluation-service,
+// which evaluates the resource's policy against the (possibly anonymous)
+// caller. This unblocks the public file-serve route, which must serve
+// public-bucket visuals to non-authenticated users — those documents'
+// authorization policies grant `read` to the `global-anonymous` credential
+// that every caller implicitly carries.
 func JWTExtractor(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		auth := r.Header.Get("Authorization")
-		if !strings.HasPrefix(auth, "Bearer ") {
-			writeJSONError(w, http.StatusUnauthorized, "missing or invalid authorization header")
-			return
-		}
-		token := strings.TrimPrefix(auth, "Bearer ")
-
-		parts := strings.Split(token, ".")
-		if len(parts) < 2 {
-			writeJSONError(w, http.StatusUnauthorized, "invalid token format")
-			return
-		}
-
-		payload, err := base64.RawURLEncoding.DecodeString(parts[1])
-		if err != nil {
-			writeJSONError(w, http.StatusUnauthorized, "invalid token encoding")
-			return
-		}
-
-		var claims map[string]any
-		if err := json.Unmarshal(payload, &claims); err != nil {
-			writeJSONError(w, http.StatusUnauthorized, "invalid token payload")
-			return
-		}
-
-		actorID, ok := claims["alkemio_actor_id"].(string)
-		if !ok || actorID == "" {
-			writeJSONError(w, http.StatusUnauthorized, "missing alkemio_actor_id claim")
-			return
-		}
-
+		actorID := extractActorID(r.Header.Get("Authorization"))
 		ctx := context.WithValue(r.Context(), ctxKeyActorID, actorID)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
+}
+
+// extractActorID parses an Authorization header and returns the
+// alkemio_actor_id claim if present and non-empty. Any failure to extract
+// (missing header, wrong scheme, malformed JWT, missing/empty claim)
+// returns "" — anonymous. The function never errors; the auth-evaluation
+// service is the policy decision point, not this parser.
+func extractActorID(auth string) string {
+	if !strings.HasPrefix(auth, "Bearer ") {
+		return ""
+	}
+	parts := strings.Split(strings.TrimPrefix(auth, "Bearer "), ".")
+	if len(parts) < 2 {
+		return ""
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return ""
+	}
+	var claims map[string]any
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return ""
+	}
+	if id, ok := claims["alkemio_actor_id"].(string); ok {
+		return id
+	}
+	return ""
 }
 
 // RequestLogger logs request start/end with duration.

--- a/internal/adapter/inbound/http/middleware_test.go
+++ b/internal/adapter/inbound/http/middleware_test.go
@@ -35,53 +35,52 @@ func TestJWTMiddleware_ValidJWT(t *testing.T) {
 	}
 }
 
-func TestJWTMiddleware_MissingAuth(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/test", nil)
-
-	handler := JWTExtractor(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
-		t.Fatal("handler should not be called")
-	}))
-
-	rr := httptest.NewRecorder()
-	handler.ServeHTTP(rr, req)
-
-	if rr.Code != http.StatusUnauthorized {
-		t.Fatalf("status = %d, want 401", rr.Code)
+// JWTExtractor is a permissive parser, not a gatekeeper. Anonymous requests
+// (no header, malformed token, missing claim) flow through with empty actorID;
+// the auth-evaluation-service makes the policy decision downstream.
+func TestJWTMiddleware_AnonymousCases(t *testing.T) {
+	cases := []struct {
+		name      string
+		setHeader bool
+		headerVal string
+	}{
+		{"NoAuthHeader", false, ""},
+		{"NonBearerScheme", true, "Basic dXNlcjpwYXNz"},
+		{"BearerNotJWT", true, "Bearer not-a-jwt"},
+		{"BearerMalformedBase64", true, "Bearer header.NOT_BASE64!.sig"},
+		{"BearerNoActorClaim", true, "Bearer " + fakeJWT(t, map[string]any{"sub": "some-user"})},
+		{"BearerEmptyActorClaim", true, "Bearer " + fakeJWT(t, map[string]any{"alkemio_actor_id": ""})},
 	}
-}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			if tc.setHeader {
+				req.Header.Set("Authorization", tc.headerVal)
+			}
 
-func TestJWTMiddleware_InvalidToken(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/test", nil)
-	req.Header.Set("Authorization", "Bearer not-a-jwt")
+			var (
+				handlerCalled bool
+				gotActorID    string
+			)
+			handler := JWTExtractor(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				handlerCalled = true
+				gotActorID = GetActorID(r.Context())
+				w.WriteHeader(http.StatusOK)
+			}))
 
-	handler := JWTExtractor(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
-		t.Fatal("handler should not be called")
-	}))
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
 
-	rr := httptest.NewRecorder()
-	handler.ServeHTTP(rr, req)
-
-	if rr.Code != http.StatusUnauthorized {
-		t.Fatalf("status = %d, want 401", rr.Code)
-	}
-}
-
-func TestJWTMiddleware_MissingActorClaim(t *testing.T) {
-	payload := map[string]any{"sub": "some-user"}
-	token := fakeJWT(t, payload)
-
-	req := httptest.NewRequest(http.MethodGet, "/test", nil)
-	req.Header.Set("Authorization", "Bearer "+token)
-
-	handler := JWTExtractor(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
-		t.Fatal("handler should not be called")
-	}))
-
-	rr := httptest.NewRecorder()
-	handler.ServeHTTP(rr, req)
-
-	if rr.Code != http.StatusUnauthorized {
-		t.Fatalf("status = %d, want 401", rr.Code)
+			if !handlerCalled {
+				t.Fatal("handler must be called for anonymous requests; middleware must not 401")
+			}
+			if rr.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200 (middleware passes through)", rr.Code)
+			}
+			if gotActorID != "" {
+				t.Errorf("actorID = %q, want empty for anonymous", gotActorID)
+			}
+		})
 	}
 }
 

--- a/internal/adapter/inbound/http/public_handler.go
+++ b/internal/adapter/inbound/http/public_handler.go
@@ -33,11 +33,10 @@ func (h *PublicHandler) ServeDocument(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// actorID may be empty here: anonymous requests are valid input.
+	// The auth-evaluation-service evaluates the document's policy
+	// against the (possibly anonymous) caller and returns the decision.
 	actorID := GetActorID(r.Context())
-	if actorID == "" {
-		writeJSONError(w, http.StatusUnauthorized, "missing actor identity")
-		return
-	}
 
 	doc, err := h.Repo.GetByID(r.Context(), docID)
 	if err != nil {
@@ -50,7 +49,10 @@ func (h *PublicHandler) ServeDocument(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Authorization via NATS
+	// Authorization check via h2c HTTP/2 (or NATS fallback). For anonymous
+	// callers, actorID is empty — the auth-evaluation-service treats that
+	// as "no asserted identity" and matches against global-anonymous
+	// credential rules in the document's authorization policy.
 	result, err := h.Auth.CheckPrivilege(r.Context(), actorID, "read", doc.AuthorizationID.String())
 	if err != nil {
 		writeJSONError(w, http.StatusServiceUnavailable, "authorization service unavailable")

--- a/internal/adapter/inbound/http/public_handler_test.go
+++ b/internal/adapter/inbound/http/public_handler_test.go
@@ -58,9 +58,19 @@ func (m *mockDocRepo) CountByExternalID(_ context.Context, _ string) (int, error
 type mockAuth struct {
 	result model.AuthResult
 	err    error
+
+	// Captured args from the most recent CheckPrivilege call.
+	calls            int
+	lastActorID      string
+	lastPrivilege    string
+	lastAuthPolicyID string
 }
 
-func (m *mockAuth) CheckPrivilege(_ context.Context, _, _, _ string) (model.AuthResult, error) {
+func (m *mockAuth) CheckPrivilege(_ context.Context, actorID, privilege, authPolicyID string) (model.AuthResult, error) {
+	m.calls++
+	m.lastActorID = actorID
+	m.lastPrivilege = privilege
+	m.lastAuthPolicyID = authPolicyID
 	return m.result, m.err
 }
 

--- a/internal/adapter/inbound/http/router_test.go
+++ b/internal/adapter/inbound/http/router_test.go
@@ -114,16 +114,20 @@ func TestRouter_DebugVars(t *testing.T) {
 	}
 }
 
-func TestRouter_PublicDocumentRequiresJWT(t *testing.T) {
+// Anonymous reach-through: the public route does NOT 401 on a missing JWT.
+// JWTExtractor is permissive; the auth-evaluation-service decides whether
+// anonymous reads are allowed against the document's policy.
+// With testRouter()'s mockAuth allowing all requests, anonymous → 200.
+func TestRouter_PublicDocument_AcceptsAnonymous(t *testing.T) {
 	r := testRouter()
 
 	req := httptest.NewRequest(http.MethodGet, "/rest/storage/document/"+uuid.New().String(), nil)
-	// No Authorization header
+	// No Authorization header — anonymous
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
 
-	if rr.Code != http.StatusUnauthorized {
-		t.Errorf("GET /rest/storage/document/:id without JWT = %d, want 401", rr.Code)
+	if rr.Code == http.StatusUnauthorized {
+		t.Errorf("GET /rest/storage/document/:id without JWT must not 401 — middleware is permissive, auth-eval is the policy decision point")
 	}
 }
 

--- a/internal/adapter/inbound/http/router_test.go
+++ b/internal/adapter/inbound/http/router_test.go
@@ -117,7 +117,7 @@ func TestRouter_DebugVars(t *testing.T) {
 // Anonymous reach-through: the public route does NOT 401 on a missing JWT.
 // JWTExtractor is permissive; the auth-evaluation-service decides whether
 // anonymous reads are allowed against the document's policy.
-// With testRouter()'s mockAuth allowing all requests, anonymous → 200.
+// testRouter() seeds a doc and a permissive mockAuth, so anonymous → 200.
 func TestRouter_PublicDocument_AcceptsAnonymous(t *testing.T) {
 	r := testRouter()
 
@@ -126,8 +126,8 @@ func TestRouter_PublicDocument_AcceptsAnonymous(t *testing.T) {
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
 
-	if rr.Code == http.StatusUnauthorized {
-		t.Errorf("GET /rest/storage/document/:id without JWT must not 401 — middleware is permissive, auth-eval is the policy decision point")
+	if rr.Code != http.StatusOK {
+		t.Errorf("GET /rest/storage/document/:id without JWT = %d, want 200 (auth-eval allows anonymous via testRouter mock)", rr.Code)
 	}
 }
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -523,12 +523,6 @@ paths:
           content:
             application/octet-stream: {}
           description: Not Modified
-        "401":
-          content:
-            application/octet-stream:
-              schema:
-                $ref: '#/components/schemas/http.errorResponse'
-          description: Unauthorized
         "403":
           content:
             application/octet-stream:


### PR DESCRIPTION
## Background

A regression was reported on staging: anonymous users see broken images everywhere on public spaces (banners, avatars, callout visuals). The error log shows:

\`\`\`
GET /api/private/rest/storage/document/{id}
401 {\"error\":\"Unauthorized\",\"message\":\"missing alkemio_actor_id claim\"}
\`\`\`

The old TS file-service supported anonymous reads by forwarding the request to the server's authorization policy, which has \`global-anonymous\` credential rules granting \`read\` on public-bucket documents. The new Go file-service rejects every anonymous request at \`JWTExtractor\` middleware before the policy is ever consulted.

## What's broken (was here, fixed in this PR)

Two layers of \`401 \"missing alkemio_actor_id claim\"\` in this repo:

1. \`JWTExtractor\` middleware unconditionally requires \`Bearer\` + non-empty \`alkemio_actor_id\` claim
2. \`PublicHandler.ServeDocument\` redundantly checks empty \`actorID\` and 401s

## Fix

\`JWTExtractor\` is now a permissive parser — never 401s. Anonymous requests (no header, malformed token, missing claim, empty claim) flow through with empty actorID. All policy decisions belong to the auth-evaluation-service.

\`PublicHandler.ServeDocument\` drops the redundant 401 guard. Empty actorID is passed to \`Auth.CheckPrivilege\`; auth-eval evaluates the document's policy against the (possibly anonymous) caller and returns the decision.

Stale \`// Authorization via NATS\` comment updated (we use h2c primarily, NATS as fallback).

## Paired PR (must ship together)

\`alkem-io/authorization-evaluation-service\` PR #18 adds the auth-eval side of anonymous handling: accepts empty \`actorId\` (or \`uuid.Nil\`), skips credential fetch, synthesizes a \`global-anonymous\` credential before policy matching. Without that PR, anonymous requests still fail (just deeper in the stack — 503 from us mapping auth-eval errors).

End-to-end validation: anonymous \`GET https://acc-alkem.io/api/private/rest/storage/document/{publicVisualId}\` → 200 with the file bytes.

## Test plan

- [x] \`JWTExtractor\`: table-driven anonymous cases (no header, non-Bearer scheme, malformed JWT, malformed base64, no claim, empty claim) all produce empty actorID and proceed
- [x] \`PublicHandler.ServeDocument\`: anonymous + deny policy → 403; anonymous + allow policy → 200 with file bytes
- [x] Router test: public route accepts anonymous (does not 401 without JWT)
- [x] Authenticated path unchanged — \`TestJWTMiddleware_ValidJWT\` still asserts the claim is extracted
- [x] All existing tests pass; lint clean
- [x] OpenAPI regenerated — 401 response removed from public endpoint, since the handler no longer returns it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Anonymous access to public resources is supported: requests without a validated JWT actor proceed to authorization evaluation.

* **Documentation**
  * OpenAPI updated: dedicated 401 response removed for the public document endpoint.

* **Tests**
  * Tests updated to confirm anonymous requests reach authorization evaluation and to verify resulting responses (200/403) and auth-eval behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->