### PR TITLE
Accept displayName on PATCH /internal/file/{id}

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"08d95700-a8cf-462d-ac54-497b2fa51ba9","pid":30915,"procStart":"Tue Apr 28 10:19:01 2026","acquiredAt":1777541936689}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"08d95700-a8cf-462d-ac54-497b2fa51ba9","pid":30915,"procStart":"Tue Apr 28 10:19:01 2026","acquiredAt":1777541936689}

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ vendor/
 
 # sqlc generated (tracked, but ignore local overrides)
 # internal/adapter/outbound/alkemiodb/queries/ is tracked
+
+# Local Claude Code state
+.claude/

--- a/db/queries/document.sql
+++ b/db/queries/document.sql
@@ -29,10 +29,18 @@ UPDATE file
 SET "externalID" = $2, "mimeType" = $3, size = $4, "updatedDate" = $5
 WHERE id = $1;
 
--- name: UpdateDocumentLocation :execrows
+-- name: UpdateDocumentMetadata :execrows
+-- Updates the mutable metadata fields (storageBucketId, temporaryLocation,
+-- displayName) atomically with optimistic locking. Caller fills unchanged
+-- fields with their current values. mimeType, externalID, size are not
+-- mutable through this query — they change only via UpdateDocumentFile.
 UPDATE file
-SET "storageBucketId" = $2, "temporaryLocation" = $3, "updatedDate" = $4, version = version + 1
-WHERE id = $1 AND version = $5;
+SET "storageBucketId"    = $2,
+    "temporaryLocation"  = $3,
+    "displayName"        = $4,
+    "updatedDate"        = $5,
+    version              = version + 1
+WHERE id = $1 AND version = $6;
 
 -- name: DeleteDocument :one
 DELETE FROM file

--- a/internal/adapter/inbound/http/document_handler.go
+++ b/internal/adapter/inbound/http/document_handler.go
@@ -344,7 +344,20 @@ func (h *DocumentHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	resp.Render(w)
 }
 
-// Update handles PATCH /internal/document/{id}
+// Update handles PATCH /internal/file/{id}.
+// Mutates storageBucketId, temporaryLocation, and/or displayName. Each
+// field is optional; at least one must be present. Omitted fields retain
+// their current value.
+//
+// displayName notes:
+//   - Validation rejects empty/whitespace-only, length > 512 (matches
+//     the file."displayName" VARCHAR(512) column), path separators, and
+//     control characters.
+//   - mimeType is immutable on this endpoint, so callers renaming a file
+//     are responsible for keeping the extension consistent with mimeType.
+//     This service does not parse extensions or enforce mimeType matching.
+//   - displayName is not part of any uniqueness/dedup index, so renames
+//     never conflict at the DB level.
 func (h *DocumentHandler) Update(w http.ResponseWriter, r *http.Request) {
 	docID, err := parseDocID(r)
 	if err != nil {
@@ -358,13 +371,18 @@ func (h *DocumentHandler) Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Need at least one field
-	if body.StorageBucketID == nil && body.TemporaryLocation == nil {
+	if body.StorageBucketID == nil && body.TemporaryLocation == nil && body.DisplayName == nil {
 		writeJSONError(w, http.StatusBadRequest, "no fields to update")
 		return
 	}
 
-	// Get current doc to fill defaults
+	if body.DisplayName != nil {
+		if err := validateDisplayName(*body.DisplayName); err != nil {
+			writeJSONError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+	}
+
 	doc, err := h.Service.Repo.GetByID(r.Context(), docID)
 	if err != nil {
 		if errors.Is(err, model.ErrDocumentNotFound) {
@@ -391,7 +409,12 @@ func (h *DocumentHandler) Update(w http.ResponseWriter, r *http.Request) {
 		tempLoc = *body.TemporaryLocation
 	}
 
-	updated, err := h.Service.UpdateDocumentLocation(r.Context(), docID, bucketID, tempLoc, doc.Version)
+	displayName := doc.DisplayName
+	if body.DisplayName != nil {
+		displayName = *body.DisplayName
+	}
+
+	updated, err := h.Service.UpdateDocumentMetadata(r.Context(), docID, bucketID, tempLoc, displayName, doc.Version)
 	if err != nil {
 		if errors.Is(err, service.ErrConflict) {
 			writeJSONError(w, http.StatusConflict, "document was modified concurrently, retry with fresh version")
@@ -406,7 +429,29 @@ func (h *DocumentHandler) Update(w http.ResponseWriter, r *http.Request) {
 		ID:                updated.ID.String(),
 		StorageBucketID:   updated.StorageBucketID.String(),
 		TemporaryLocation: updated.TemporaryLocation,
+		DisplayName:       updated.DisplayName,
 	}.Render(w)
+}
+
+// validateDisplayName rejects renames that would corrupt the row or
+// produce a filename consumers can't safely use. The file."displayName"
+// column is VARCHAR(512), so 512 bytes is the hard upper bound.
+func validateDisplayName(name string) error {
+	if strings.TrimSpace(name) == "" {
+		return fmt.Errorf("displayName must not be empty or whitespace-only")
+	}
+	if len(name) > 512 {
+		return fmt.Errorf("displayName exceeds maximum length of 512 characters")
+	}
+	if strings.ContainsAny(name, `/\`) {
+		return fmt.Errorf("displayName must not contain path separators ('/' or '\\')")
+	}
+	for _, r := range name {
+		if r < 0x20 || r == 0x7f {
+			return fmt.Errorf("displayName must not contain control characters")
+		}
+	}
+	return nil
 }
 
 // ReplaceContent handles PUT /internal/document/{id}/content (store-and-link)

--- a/internal/adapter/inbound/http/document_handler.go
+++ b/internal/adapter/inbound/http/document_handler.go
@@ -98,8 +98,8 @@ func parseCreateForm(r *http.Request) (content []byte, declaredMIME string, inpu
 	}
 
 	displayName := r.FormValue("displayName")
-	if displayName == "" {
-		return nil, "", input, nil, 0, fmt.Errorf("displayName is required")
+	if err := validateDisplayName(displayName); err != nil {
+		return nil, "", input, nil, 0, err
 	}
 
 	storageBucketID, err := uuid.Parse(r.FormValue("storageBucketId"))
@@ -366,8 +366,10 @@ func (h *DocumentHandler) Update(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var body UpdateDocumentRequest
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		writeJSONError(w, http.StatusBadRequest, "invalid JSON body")
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields() // immutable fields like mimeType must not silently no-op
+	if err := dec.Decode(&body); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
 		return
 	}
 
@@ -420,6 +422,10 @@ func (h *DocumentHandler) Update(w http.ResponseWriter, r *http.Request) {
 			writeJSONError(w, http.StatusConflict, "document was modified concurrently, retry with fresh version")
 			return
 		}
+		if errors.Is(err, model.ErrDuplicateKey) {
+			writeJSONError(w, http.StatusConflict, "destination bucket already contains a document with this content")
+			return
+		}
 		h.Logger.Error("failed to update document", zap.Error(err))
 		writeJSONError(w, http.StatusInternalServerError, "internal error")
 		return
@@ -434,14 +440,18 @@ func (h *DocumentHandler) Update(w http.ResponseWriter, r *http.Request) {
 }
 
 // validateDisplayName rejects renames that would corrupt the row or
-// produce a filename consumers can't safely use. The file."displayName"
-// column is VARCHAR(512), so 512 bytes is the hard upper bound.
+// produce a filename consumers can't safely use. Shared by POST (create)
+// and PATCH (update) so both paths apply the same rules.
+//
+// The 512-byte cap is intentionally tighter than file."displayName"
+// VARCHAR(512), which is character-based in Postgres: capping at bytes
+// guarantees any accepted value fits regardless of UTF-8 expansion.
 func validateDisplayName(name string) error {
 	if strings.TrimSpace(name) == "" {
 		return fmt.Errorf("displayName must not be empty or whitespace-only")
 	}
 	if len(name) > 512 {
-		return fmt.Errorf("displayName exceeds maximum length of 512 characters")
+		return fmt.Errorf("displayName exceeds maximum length of 512 bytes")
 	}
 	if strings.ContainsAny(name, `/\`) {
 		return fmt.Errorf("displayName must not contain path separators ('/' or '\\')")

--- a/internal/adapter/inbound/http/document_handler.go
+++ b/internal/adapter/inbound/http/document_handler.go
@@ -241,8 +241,14 @@ func (h *DocumentHandler) Create(w http.ResponseWriter, r *http.Request) {
 // (existing row is authoritative), matching the createDocument contract.
 func (h *DocumentHandler) Copy(w http.ResponseWriter, r *http.Request) {
 	var body CopyDocumentRequest
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		writeJSONError(w, http.StatusBadRequest, "invalid JSON body")
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&body); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+		return
+	}
+	if dec.More() {
+		writeJSONError(w, http.StatusBadRequest, "invalid JSON body: trailing data after first object")
 		return
 	}
 
@@ -370,6 +376,10 @@ func (h *DocumentHandler) Update(w http.ResponseWriter, r *http.Request) {
 	dec.DisallowUnknownFields() // immutable fields like mimeType must not silently no-op
 	if err := dec.Decode(&body); err != nil {
 		writeJSONError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+		return
+	}
+	if dec.More() {
+		writeJSONError(w, http.StatusBadRequest, "invalid JSON body: trailing data after first object")
 		return
 	}
 

--- a/internal/adapter/inbound/http/document_handler_test.go
+++ b/internal/adapter/inbound/http/document_handler_test.go
@@ -1392,3 +1392,181 @@ func TestInitMetrics(_ *testing.T) {
 	InitMetrics()
 	InitMetrics() // idempotent
 }
+
+// --- PATCH displayName ---
+
+func TestDocumentHandler_Patch_DisplayName_Happy(t *testing.T) {
+	h, repo, _ := newDocHandler()
+	docID := uuid.New()
+	bucket := uuid.New()
+	repo.doc = model.Document{
+		ID:                docID,
+		StorageBucketID:   bucket,
+		TemporaryLocation: false,
+		DisplayName:       "renamed.txt",
+		Version:           7,
+	}
+
+	r := chi.NewRouter()
+	r.Patch("/internal/file/{id}", h.Update)
+
+	body := `{"displayName": "renamed.txt"}`
+	req := httptest.NewRequest(http.MethodPatch, "/internal/file/"+docID.String(), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200, body: %s", rr.Code, rr.Body.String())
+	}
+	if repo.updateMetadataCalls != 1 {
+		t.Fatalf("UpdateMetadata calls = %d, want 1", repo.updateMetadataCalls)
+	}
+	if repo.lastUpdateDisplayName != "renamed.txt" {
+		t.Errorf("displayName passed = %q, want %q", repo.lastUpdateDisplayName, "renamed.txt")
+	}
+	if repo.lastUpdateBucketID != bucket {
+		t.Errorf("bucketID passed = %s, want %s (should fall through from current)", repo.lastUpdateBucketID, bucket)
+	}
+	if repo.lastUpdateTemporary {
+		t.Errorf("temporary passed = %v, want false (should fall through)", repo.lastUpdateTemporary)
+	}
+	if repo.lastUpdateVersion != 7 {
+		t.Errorf("version passed = %d, want 7 (current version for optimistic lock)", repo.lastUpdateVersion)
+	}
+
+	var resp UpdateDocumentResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.DisplayName != "renamed.txt" {
+		t.Errorf("response displayName = %q, want %q", resp.DisplayName, "renamed.txt")
+	}
+}
+
+func TestDocumentHandler_Patch_DisplayName_Idempotent(t *testing.T) {
+	// Renaming to the same name twice: handler/service does not branch on
+	// "no-op", but the row's version still advances (DB UPDATE always
+	// runs). The contract is "stable result", not "no DB write".
+	h, repo, _ := newDocHandler()
+	docID := uuid.New()
+	repo.doc = model.Document{
+		ID:              docID,
+		StorageBucketID: uuid.New(),
+		DisplayName:     "stable.txt",
+		Version:         3,
+	}
+
+	r := chi.NewRouter()
+	r.Patch("/internal/file/{id}", h.Update)
+
+	body := `{"displayName": "stable.txt"}`
+	for i := 0; i < 2; i++ {
+		req := httptest.NewRequest(http.MethodPatch, "/internal/file/"+docID.String(), strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		rr := httptest.NewRecorder()
+		r.ServeHTTP(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("iteration %d: status = %d, want 200, body: %s", i, rr.Code, rr.Body.String())
+		}
+		if repo.lastUpdateDisplayName != "stable.txt" {
+			t.Errorf("iteration %d: displayName = %q, want stable.txt", i, repo.lastUpdateDisplayName)
+		}
+	}
+	if repo.updateMetadataCalls != 2 {
+		t.Errorf("UpdateMetadata calls = %d, want 2", repo.updateMetadataCalls)
+	}
+}
+
+func TestDocumentHandler_Patch_DisplayName_CombinedFields(t *testing.T) {
+	h, repo, _ := newDocHandler()
+	docID := uuid.New()
+	newBucket := uuid.New()
+	repo.doc = model.Document{
+		ID:                docID,
+		StorageBucketID:   uuid.New(),
+		TemporaryLocation: true,
+		DisplayName:       "new.pdf",
+		Version:           1,
+	}
+
+	r := chi.NewRouter()
+	r.Patch("/internal/file/{id}", h.Update)
+
+	body := `{"storageBucketId":"` + newBucket.String() + `","temporaryLocation":false,"displayName":"new.pdf"}`
+	req := httptest.NewRequest(http.MethodPatch, "/internal/file/"+docID.String(), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200, body: %s", rr.Code, rr.Body.String())
+	}
+	if repo.lastUpdateBucketID != newBucket {
+		t.Errorf("bucketID = %s, want %s", repo.lastUpdateBucketID, newBucket)
+	}
+	if repo.lastUpdateTemporary {
+		t.Errorf("temporary = %v, want false", repo.lastUpdateTemporary)
+	}
+	if repo.lastUpdateDisplayName != "new.pdf" {
+		t.Errorf("displayName = %q, want new.pdf", repo.lastUpdateDisplayName)
+	}
+}
+
+func TestDocumentHandler_Patch_DisplayName_Validation(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"empty", `{"displayName":""}`},
+		{"whitespace_only", `{"displayName":"   "}`},
+		{"too_long", `{"displayName":"` + strings.Repeat("a", 513) + `"}`},
+		{"forward_slash", `{"displayName":"sub/dir.txt"}`},
+		{"backslash", `{"displayName":"sub\\dir.txt"}`},
+		{"control_char_null", `{"displayName":"a\u0000b"}`},
+		{"control_char_newline", `{"displayName":"a\u000ab"}`},
+		{"control_char_del", `{"displayName":"a\u007fb"}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h, repo, _ := newDocHandler()
+			repo.doc = model.Document{ID: uuid.New(), StorageBucketID: uuid.New(), DisplayName: "ok.txt"}
+
+			r := chi.NewRouter()
+			r.Patch("/internal/file/{id}", h.Update)
+
+			req := httptest.NewRequest(http.MethodPatch, "/internal/file/"+uuid.New().String(), strings.NewReader(tc.body))
+			req.Header.Set("Content-Type", "application/json")
+			rr := httptest.NewRecorder()
+			r.ServeHTTP(rr, req)
+
+			if rr.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400, body: %s", rr.Code, rr.Body.String())
+			}
+			if repo.updateMetadataCalls != 0 {
+				t.Errorf("UpdateMetadata called %d times; should reject before service", repo.updateMetadataCalls)
+			}
+		})
+	}
+}
+
+func TestDocumentHandler_Patch_DisplayName_LengthBoundary(t *testing.T) {
+	// Exactly 512 bytes is the largest accepted value (column is VARCHAR(512)).
+	h, repo, _ := newDocHandler()
+	docID := uuid.New()
+	repo.doc = model.Document{ID: docID, StorageBucketID: uuid.New(), Version: 1}
+
+	r := chi.NewRouter()
+	r.Patch("/internal/file/{id}", h.Update)
+
+	name := strings.Repeat("a", 512)
+	body := `{"displayName":"` + name + `"}`
+	req := httptest.NewRequest(http.MethodPatch, "/internal/file/"+docID.String(), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 for exactly 512-byte name, body: %s", rr.Code, rr.Body.String())
+	}
+}

--- a/internal/adapter/inbound/http/document_handler_test.go
+++ b/internal/adapter/inbound/http/document_handler_test.go
@@ -1686,6 +1686,66 @@ func TestDocumentHandler_Patch_DuplicateKey_409(t *testing.T) {
 	r.ServeHTTP(rr, req)
 
 	if rr.Code != http.StatusConflict {
-		t.Fatalf("status = %d, want 409, body: %s", rr.Code, rr.Body.String())
+		t.Fatalf("status = %d, want 409 for duplicate key, body: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestDocumentHandler_Patch_RejectsTrailingJSON(t *testing.T) {
+	// json.Decoder.Decode consumes only the first JSON value, so a body
+	// like `{"displayName":"x.txt"}{"foo":1}` would otherwise parse the
+	// first object and silently drop the second. Reject it instead.
+	h, repo, _ := newDocHandler()
+	repo.doc = model.Document{ID: uuid.New(), StorageBucketID: uuid.New()}
+
+	r := chi.NewRouter()
+	r.Patch("/internal/file/{id}", h.Update)
+
+	body := `{"displayName":"x.txt"}{"foo":1}`
+	req := httptest.NewRequest(http.MethodPatch, "/internal/file/"+uuid.New().String(), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400, body: %s", rr.Code, rr.Body.String())
+	}
+	if repo.updateMetadataCalls != 0 {
+		t.Errorf("UpdateMetadata called %d times; trailing JSON must be rejected before service", repo.updateMetadataCalls)
+	}
+}
+
+func TestDocumentHandler_Copy_RejectsTrailingJSON(t *testing.T) {
+	h, _, _ := newDocHandler()
+
+	r := chi.NewRouter()
+	r.Post("/internal/file/copy", h.Copy)
+
+	body := `{"sourceId":"` + uuid.New().String() + `","destinationBucketId":"` + uuid.New().String() + `","authorizationId":"` + uuid.New().String() + `"}{"extra":1}`
+	req := httptest.NewRequest(http.MethodPost, "/internal/file/copy", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400, body: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestDocumentHandler_Copy_RejectsUnknownFields(t *testing.T) {
+	// Tightening the Copy decoder along with the trailing-data check
+	// also catches caller typos and immutable-field attempts.
+	h, _, _ := newDocHandler()
+
+	r := chi.NewRouter()
+	r.Post("/internal/file/copy", h.Copy)
+
+	body := `{"sourceId":"` + uuid.New().String() + `","destinationBucketId":"` + uuid.New().String() + `","authorizationId":"` + uuid.New().String() + `","mimeType":"text/plain"}`
+	req := httptest.NewRequest(http.MethodPost, "/internal/file/copy", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400, body: %s", rr.Code, rr.Body.String())
 	}
 }

--- a/internal/adapter/inbound/http/document_handler_test.go
+++ b/internal/adapter/inbound/http/document_handler_test.go
@@ -39,6 +39,28 @@ func (p *stubProcessor) Process(content []byte, mimeType string) ([]byte, string
 	return content, mimeType, nil
 }
 
+// runPatch wires a fresh handler + chi router and dispatches a single
+// PATCH /internal/file/{id} request with the given JSON body. The
+// configure callback (if non-nil) lets the caller seed mock state on
+// the repo before the request is served. Returns the response recorder
+// and the captured repo so callers can assert status + UpdateMetadata
+// args without repeating chi/httptest boilerplate per test.
+func runPatch(t *testing.T, docID uuid.UUID, body string, configure func(*mockDocRepo)) (*httptest.ResponseRecorder, *mockDocRepo) {
+	t.Helper()
+	h, repo, _ := newDocHandler()
+	if configure != nil {
+		configure(repo)
+	}
+	r := chi.NewRouter()
+	r.Patch("/internal/file/{id}", h.Update)
+
+	req := httptest.NewRequest(http.MethodPatch, "/internal/file/"+docID.String(), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+	return rr, repo
+}
+
 func TestDocumentHandler_GetMeta_Found(t *testing.T) {
 	h, repo, _ := newDocHandler()
 	docID := uuid.New()
@@ -1529,17 +1551,9 @@ func TestDocumentHandler_Patch_DisplayName_Validation(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			h, repo, _ := newDocHandler()
-			repo.doc = model.Document{ID: uuid.New(), StorageBucketID: uuid.New(), DisplayName: "ok.txt"}
-
-			r := chi.NewRouter()
-			r.Patch("/internal/file/{id}", h.Update)
-
-			req := httptest.NewRequest(http.MethodPatch, "/internal/file/"+uuid.New().String(), strings.NewReader(tc.body))
-			req.Header.Set("Content-Type", "application/json")
-			rr := httptest.NewRecorder()
-			r.ServeHTTP(rr, req)
-
+			rr, repo := runPatch(t, uuid.New(), tc.body, func(repo *mockDocRepo) {
+				repo.doc = model.Document{ID: uuid.New(), StorageBucketID: uuid.New(), DisplayName: "ok.txt"}
+			})
 			if rr.Code != http.StatusBadRequest {
 				t.Fatalf("status = %d, want 400, body: %s", rr.Code, rr.Body.String())
 			}
@@ -1564,24 +1578,15 @@ func TestDocumentHandler_Patch_DisplayName_LengthBoundary(t *testing.T) {
 		{"ascii_513", strings.Repeat("a", 513), http.StatusBadRequest},
 		// "€" = 3 bytes in UTF-8. 170*3 + 2 = 512 bytes exactly.
 		{"utf8_512_bytes_172_runes", strings.Repeat("€", 170) + "ab", http.StatusOK},
-		// One more "€" pushes to 513 bytes (171*3 + 2 = 515, pick 170+1+rest).
+		// 171 * 3 = 513 bytes, just over the limit.
 		{"utf8_over_512_bytes", strings.Repeat("€", 171), http.StatusBadRequest},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			h, repo, _ := newDocHandler()
 			docID := uuid.New()
-			repo.doc = model.Document{ID: docID, StorageBucketID: uuid.New(), Version: 1}
-
-			r := chi.NewRouter()
-			r.Patch("/internal/file/{id}", h.Update)
-
-			body := `{"displayName":"` + tc.display + `"}`
-			req := httptest.NewRequest(http.MethodPatch, "/internal/file/"+docID.String(), strings.NewReader(body))
-			req.Header.Set("Content-Type", "application/json")
-			rr := httptest.NewRecorder()
-			r.ServeHTTP(rr, req)
-
+			rr, repo := runPatch(t, docID, `{"displayName":"`+tc.display+`"}`, func(repo *mockDocRepo) {
+				repo.doc = model.Document{ID: docID, StorageBucketID: uuid.New(), Version: 1}
+			})
 			if rr.Code != tc.wantCode {
 				t.Fatalf("status = %d, want %d (display has %d bytes), body: %s", rr.Code, tc.wantCode, len(tc.display), rr.Body.String())
 			}
@@ -1606,17 +1611,9 @@ func TestDocumentHandler_Patch_RejectsUnknownFields(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			h, repo, _ := newDocHandler()
-			repo.doc = model.Document{ID: uuid.New(), StorageBucketID: uuid.New()}
-
-			r := chi.NewRouter()
-			r.Patch("/internal/file/{id}", h.Update)
-
-			req := httptest.NewRequest(http.MethodPatch, "/internal/file/"+uuid.New().String(), strings.NewReader(tc.body))
-			req.Header.Set("Content-Type", "application/json")
-			rr := httptest.NewRecorder()
-			r.ServeHTTP(rr, req)
-
+			rr, repo := runPatch(t, uuid.New(), tc.body, func(repo *mockDocRepo) {
+				repo.doc = model.Document{ID: uuid.New(), StorageBucketID: uuid.New()}
+			})
 			if rr.Code != http.StatusBadRequest {
 				t.Fatalf("status = %d, want 400, body: %s", rr.Code, rr.Body.String())
 			}
@@ -1671,20 +1668,11 @@ func TestDocumentHandler_Patch_DuplicateKey_409(t *testing.T) {
 	// Defensive: if a UNIQUE constraint (e.g. (externalID, storageBucketId))
 	// fires when the caller PATCHes a doc into a bucket that already
 	// contains the same blob, the handler must surface 409, not 500.
-	h, repo, _ := newDocHandler()
 	docID := uuid.New()
-	repo.doc = model.Document{ID: docID, StorageBucketID: uuid.New(), Version: 1}
-	repo.updateErr = model.ErrDuplicateKey
-
-	r := chi.NewRouter()
-	r.Patch("/internal/file/{id}", h.Update)
-
-	body := `{"storageBucketId":"` + uuid.New().String() + `"}`
-	req := httptest.NewRequest(http.MethodPatch, "/internal/file/"+docID.String(), strings.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	rr := httptest.NewRecorder()
-	r.ServeHTTP(rr, req)
-
+	rr, _ := runPatch(t, docID, `{"storageBucketId":"`+uuid.New().String()+`"}`, func(repo *mockDocRepo) {
+		repo.doc = model.Document{ID: docID, StorageBucketID: uuid.New(), Version: 1}
+		repo.updateErr = model.ErrDuplicateKey
+	})
 	if rr.Code != http.StatusConflict {
 		t.Fatalf("status = %d, want 409 for duplicate key, body: %s", rr.Code, rr.Body.String())
 	}
@@ -1694,18 +1682,9 @@ func TestDocumentHandler_Patch_RejectsTrailingJSON(t *testing.T) {
 	// json.Decoder.Decode consumes only the first JSON value, so a body
 	// like `{"displayName":"x.txt"}{"foo":1}` would otherwise parse the
 	// first object and silently drop the second. Reject it instead.
-	h, repo, _ := newDocHandler()
-	repo.doc = model.Document{ID: uuid.New(), StorageBucketID: uuid.New()}
-
-	r := chi.NewRouter()
-	r.Patch("/internal/file/{id}", h.Update)
-
-	body := `{"displayName":"x.txt"}{"foo":1}`
-	req := httptest.NewRequest(http.MethodPatch, "/internal/file/"+uuid.New().String(), strings.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	rr := httptest.NewRecorder()
-	r.ServeHTTP(rr, req)
-
+	rr, repo := runPatch(t, uuid.New(), `{"displayName":"x.txt"}{"foo":1}`, func(repo *mockDocRepo) {
+		repo.doc = model.Document{ID: uuid.New(), StorageBucketID: uuid.New()}
+	})
 	if rr.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400, body: %s", rr.Code, rr.Body.String())
 	}

--- a/internal/adapter/inbound/http/document_handler_test.go
+++ b/internal/adapter/inbound/http/document_handler_test.go
@@ -1508,7 +1508,7 @@ func TestDocumentHandler_Patch_DisplayName_CombinedFields(t *testing.T) {
 		ID:                docID,
 		StorageBucketID:   uuid.New(),
 		TemporaryLocation: true,
-		DisplayName:       "new.pdf",
+		DisplayName:       "old.pdf", // fixture differs from body so a missing rename fails the test
 		Version:           1,
 	}
 
@@ -1635,6 +1635,9 @@ func TestDocumentHandler_Create_RejectsInvalidDisplayName(t *testing.T) {
 		{"forward_slash", "sub/dir.txt"},
 		{"backslash", `sub\dir.txt`},
 		{"too_long", strings.Repeat("a", 513)},
+		{"control_char_null", "a\x00b"},
+		{"control_char_newline", "a\nb"},
+		{"control_char_del", "a\x7fb"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1668,6 +1671,9 @@ func TestDocumentHandler_Patch_DuplicateKey_409(t *testing.T) {
 	// Defensive: if a UNIQUE constraint (e.g. (externalID, storageBucketId))
 	// fires when the caller PATCHes a doc into a bucket that already
 	// contains the same blob, the handler must surface 409, not 500.
+	// Asserting the body too pins the duplicate-key vs version-conflict
+	// distinction so callers can act on it without parsing structured
+	// error codes.
 	docID := uuid.New()
 	rr, _ := runPatch(t, docID, `{"storageBucketId":"`+uuid.New().String()+`"}`, func(repo *mockDocRepo) {
 		repo.doc = model.Document{ID: docID, StorageBucketID: uuid.New(), Version: 1}
@@ -1675,6 +1681,9 @@ func TestDocumentHandler_Patch_DuplicateKey_409(t *testing.T) {
 	})
 	if rr.Code != http.StatusConflict {
 		t.Fatalf("status = %d, want 409 for duplicate key, body: %s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "destination bucket already contains a document with this content") {
+		t.Errorf("conflict body = %q, want duplicate-key message (not version-conflict)", rr.Body.String())
 	}
 }
 

--- a/internal/adapter/inbound/http/document_handler_test.go
+++ b/internal/adapter/inbound/http/document_handler_test.go
@@ -1403,7 +1403,7 @@ func TestDocumentHandler_Patch_DisplayName_Happy(t *testing.T) {
 		ID:                docID,
 		StorageBucketID:   bucket,
 		TemporaryLocation: false,
-		DisplayName:       "renamed.txt",
+		DisplayName:       "old.txt", // genuine rename, not a no-op
 		Version:           7,
 	}
 
@@ -1551,22 +1551,141 @@ func TestDocumentHandler_Patch_DisplayName_Validation(t *testing.T) {
 }
 
 func TestDocumentHandler_Patch_DisplayName_LengthBoundary(t *testing.T) {
-	// Exactly 512 bytes is the largest accepted value (column is VARCHAR(512)).
+	// validateDisplayName caps at 512 bytes (intentionally tighter than
+	// VARCHAR(512), which is character-based in Postgres). These cases
+	// pin that the cap is byte-based so a future rune-based regression
+	// fails loudly.
+	cases := []struct {
+		name     string
+		display  string
+		wantCode int
+	}{
+		{"ascii_512", strings.Repeat("a", 512), http.StatusOK},
+		{"ascii_513", strings.Repeat("a", 513), http.StatusBadRequest},
+		// "€" = 3 bytes in UTF-8. 170*3 + 2 = 512 bytes exactly.
+		{"utf8_512_bytes_172_runes", strings.Repeat("€", 170) + "ab", http.StatusOK},
+		// One more "€" pushes to 513 bytes (171*3 + 2 = 515, pick 170+1+rest).
+		{"utf8_over_512_bytes", strings.Repeat("€", 171), http.StatusBadRequest},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h, repo, _ := newDocHandler()
+			docID := uuid.New()
+			repo.doc = model.Document{ID: docID, StorageBucketID: uuid.New(), Version: 1}
+
+			r := chi.NewRouter()
+			r.Patch("/internal/file/{id}", h.Update)
+
+			body := `{"displayName":"` + tc.display + `"}`
+			req := httptest.NewRequest(http.MethodPatch, "/internal/file/"+docID.String(), strings.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			rr := httptest.NewRecorder()
+			r.ServeHTTP(rr, req)
+
+			if rr.Code != tc.wantCode {
+				t.Fatalf("status = %d, want %d (display has %d bytes), body: %s", rr.Code, tc.wantCode, len(tc.display), rr.Body.String())
+			}
+			if tc.wantCode == http.StatusBadRequest && repo.updateMetadataCalls != 0 {
+				t.Errorf("UpdateMetadata called %d times; should reject before service", repo.updateMetadataCalls)
+			}
+		})
+	}
+}
+
+func TestDocumentHandler_Patch_RejectsUnknownFields(t *testing.T) {
+	// Immutable fields like mimeType must produce a clear 400 instead of
+	// silently no-op'ing when sent through PATCH.
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"immutable_mimeType", `{"displayName":"x.txt","mimeType":"text/plain"}`},
+		{"immutable_externalID", `{"displayName":"x.txt","externalID":"abc"}`},
+		{"immutable_size", `{"displayName":"x.txt","size":42}`},
+		{"unknown_field", `{"displayName":"x.txt","foo":"bar"}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h, repo, _ := newDocHandler()
+			repo.doc = model.Document{ID: uuid.New(), StorageBucketID: uuid.New()}
+
+			r := chi.NewRouter()
+			r.Patch("/internal/file/{id}", h.Update)
+
+			req := httptest.NewRequest(http.MethodPatch, "/internal/file/"+uuid.New().String(), strings.NewReader(tc.body))
+			req.Header.Set("Content-Type", "application/json")
+			rr := httptest.NewRecorder()
+			r.ServeHTTP(rr, req)
+
+			if rr.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400, body: %s", rr.Code, rr.Body.String())
+			}
+			if repo.updateMetadataCalls != 0 {
+				t.Errorf("UpdateMetadata called %d times; unknown-field reject must come before service", repo.updateMetadataCalls)
+			}
+		})
+	}
+}
+
+func TestDocumentHandler_Create_RejectsInvalidDisplayName(t *testing.T) {
+	// validateDisplayName must run on POST too, otherwise POST accepts
+	// names that the handler later refuses to update via PATCH.
+	cases := []struct {
+		name        string
+		displayName string
+	}{
+		{"whitespace_only", "   "},
+		{"forward_slash", "sub/dir.txt"},
+		{"backslash", `sub\dir.txt`},
+		{"too_long", strings.Repeat("a", 513)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h, _, _ := newDocHandler()
+
+			var body bytes.Buffer
+			writer := multipart.NewWriter(&body)
+			part, _ := writer.CreateFormFile("file", "test.txt")
+			_, _ = part.Write([]byte("hello"))
+			_ = writer.WriteField("displayName", tc.displayName)
+			_ = writer.WriteField("storageBucketId", uuid.New().String())
+			_ = writer.WriteField("authorizationId", uuid.New().String())
+			_ = writer.Close()
+
+			r := chi.NewRouter()
+			r.Post("/internal/file", h.Create)
+
+			req := httptest.NewRequest(http.MethodPost, "/internal/file", &body)
+			req.Header.Set("Content-Type", writer.FormDataContentType())
+			rr := httptest.NewRecorder()
+			r.ServeHTTP(rr, req)
+
+			if rr.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400, body: %s", rr.Code, rr.Body.String())
+			}
+		})
+	}
+}
+
+func TestDocumentHandler_Patch_DuplicateKey_409(t *testing.T) {
+	// Defensive: if a UNIQUE constraint (e.g. (externalID, storageBucketId))
+	// fires when the caller PATCHes a doc into a bucket that already
+	// contains the same blob, the handler must surface 409, not 500.
 	h, repo, _ := newDocHandler()
 	docID := uuid.New()
 	repo.doc = model.Document{ID: docID, StorageBucketID: uuid.New(), Version: 1}
+	repo.updateErr = model.ErrDuplicateKey
 
 	r := chi.NewRouter()
 	r.Patch("/internal/file/{id}", h.Update)
 
-	name := strings.Repeat("a", 512)
-	body := `{"displayName":"` + name + `"}`
+	body := `{"storageBucketId":"` + uuid.New().String() + `"}`
 	req := httptest.NewRequest(http.MethodPatch, "/internal/file/"+docID.String(), strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
 
-	if rr.Code != http.StatusOK {
-		t.Fatalf("status = %d, want 200 for exactly 512-byte name, body: %s", rr.Code, rr.Body.String())
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409, body: %s", rr.Code, rr.Body.String())
 	}
 }

--- a/internal/adapter/inbound/http/dto.go
+++ b/internal/adapter/inbound/http/dto.go
@@ -39,11 +39,12 @@ func (r DeleteDocumentResponse) Render(w http.ResponseWriter) {
 	_ = json.NewEncoder(w).Encode(r)
 }
 
-// UpdateDocumentResponse is returned by PATCH /internal/document/:id.
+// UpdateDocumentResponse is returned by PATCH /internal/file/:id.
 type UpdateDocumentResponse struct {
 	ID                string `json:"id"`
 	StorageBucketID   string `json:"storageBucketId"`
 	TemporaryLocation bool   `json:"temporaryLocation"`
+	DisplayName       string `json:"displayName"`
 }
 
 func (r UpdateDocumentResponse) Render(w http.ResponseWriter) {
@@ -87,10 +88,15 @@ func (r DocumentMetaResponse) Render(w http.ResponseWriter) {
 	_ = json.NewEncoder(w).Encode(r)
 }
 
-// UpdateDocumentRequest is the body for PATCH /internal/document/:id.
+// UpdateDocumentRequest is the body for PATCH /internal/file/:id.
+// All fields are optional; at least one must be present. Omitted fields
+// retain their current value. mimeType, externalID, and size are immutable
+// through this endpoint — see PUT /internal/file/{id}/content for content
+// replacement (which also updates mimeType and size).
 type UpdateDocumentRequest struct {
-	StorageBucketID   *string `json:"storageBucketId"`
-	TemporaryLocation *bool   `json:"temporaryLocation"`
+	StorageBucketID   *string `json:"storageBucketId,omitempty"`
+	TemporaryLocation *bool   `json:"temporaryLocation,omitempty"`
+	DisplayName       *string `json:"displayName,omitempty"`
 }
 
 // CopyDocumentRequest is the JSON body for POST /internal/file/copy.

--- a/internal/adapter/inbound/http/public_handler_test.go
+++ b/internal/adapter/inbound/http/public_handler_test.go
@@ -24,6 +24,13 @@ type mockDocRepo struct {
 	deleteResult model.DeletedDocument
 	deleteErr    error
 	count        int
+
+	// Captured args from the most recent UpdateMetadata call.
+	updateMetadataCalls   int
+	lastUpdateBucketID    uuid.UUID
+	lastUpdateTemporary   bool
+	lastUpdateDisplayName string
+	lastUpdateVersion     int
 }
 
 func (m *mockDocRepo) GetByID(_ context.Context, _ uuid.UUID) (model.Document, error) {
@@ -45,7 +52,12 @@ func (m *mockDocRepo) Create(_ context.Context, doc model.Document) (uuid.UUID, 
 func (m *mockDocRepo) UpdateFile(_ context.Context, _ uuid.UUID, _, _ string, _ int) error {
 	return m.updateErr
 }
-func (m *mockDocRepo) UpdateLocation(_ context.Context, _ uuid.UUID, _ uuid.UUID, _ bool, _ int) error {
+func (m *mockDocRepo) UpdateMetadata(_ context.Context, _ uuid.UUID, bucketID uuid.UUID, temporary bool, displayName string, version int) error {
+	m.updateMetadataCalls++
+	m.lastUpdateBucketID = bucketID
+	m.lastUpdateTemporary = temporary
+	m.lastUpdateDisplayName = displayName
+	m.lastUpdateVersion = version
 	return m.updateErr
 }
 func (m *mockDocRepo) Delete(_ context.Context, _ uuid.UUID) (model.DeletedDocument, error) {

--- a/internal/adapter/inbound/http/public_handler_test.go
+++ b/internal/adapter/inbound/http/public_handler_test.go
@@ -58,7 +58,17 @@ func (m *mockDocRepo) UpdateMetadata(_ context.Context, _ uuid.UUID, bucketID uu
 	m.lastUpdateTemporary = temporary
 	m.lastUpdateDisplayName = displayName
 	m.lastUpdateVersion = version
-	return m.updateErr
+	if m.updateErr != nil {
+		return m.updateErr
+	}
+	// Mirror real adapter behavior so the subsequent service GetByID
+	// reflects the update — otherwise tests can't tell whether the
+	// handler propagated the new values or returned stale ones.
+	m.doc.StorageBucketID = bucketID
+	m.doc.TemporaryLocation = temporary
+	m.doc.DisplayName = displayName
+	m.doc.Version = version + 1
+	return nil
 }
 func (m *mockDocRepo) Delete(_ context.Context, _ uuid.UUID) (model.DeletedDocument, error) {
 	return m.deleteResult, m.deleteErr

--- a/internal/adapter/outbound/alkemiodb/adapter.go
+++ b/internal/adapter/outbound/alkemiodb/adapter.go
@@ -96,11 +96,12 @@ func (a *Adapter) UpdateFile(ctx context.Context, id uuid.UUID, externalID, mime
 	return nil
 }
 
-func (a *Adapter) UpdateLocation(ctx context.Context, id uuid.UUID, storageBucketID uuid.UUID, temporaryLocation bool, version int) error {
-	rows, err := a.queries.UpdateDocumentLocation(ctx, queries.UpdateDocumentLocationParams{
+func (a *Adapter) UpdateMetadata(ctx context.Context, id uuid.UUID, storageBucketID uuid.UUID, temporaryLocation bool, displayName string, version int) error {
+	rows, err := a.queries.UpdateDocumentMetadata(ctx, queries.UpdateDocumentMetadataParams{
 		ID:                uuidToPgx(id),
 		StorageBucketId:   uuidToPgx(storageBucketID),
 		TemporaryLocation: temporaryLocation,
+		DisplayName:       displayName,
 		UpdatedDate:       timeToPgxNow(),
 		Version:           safeInt32(version),
 	})

--- a/internal/adapter/outbound/alkemiodb/adapter.go
+++ b/internal/adapter/outbound/alkemiodb/adapter.go
@@ -106,6 +106,15 @@ func (a *Adapter) UpdateMetadata(ctx context.Context, id uuid.UUID, storageBucke
 		Version:           safeInt32(version),
 	})
 	if err != nil {
+		// Defensive: keeps PATCH consistent with Create/UpdateFile if a
+		// uniqueness constraint is added later (e.g. (externalID,
+		// storageBucketId)). No such constraint exists in this repo's
+		// db/schema/document.sql today, but the production schema can
+		// diverge, and a 409 beats a 500 if it fires.
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == pgerrcode.UniqueViolation {
+			return model.ErrDuplicateKey
+		}
 		return err
 	}
 	if rows == 0 {

--- a/internal/adapter/outbound/alkemiodb/adapter_mock_test.go
+++ b/internal/adapter/outbound/alkemiodb/adapter_mock_test.go
@@ -245,7 +245,7 @@ func TestMock_CountByExternalID(t *testing.T) {
 	}
 }
 
-func TestMock_UpdateLocation_Success(t *testing.T) {
+func TestMock_UpdateMetadata_Success(t *testing.T) {
 	mock, err := pgxmock.NewPool()
 	if err != nil {
 		t.Fatal(err)
@@ -253,17 +253,17 @@ func TestMock_UpdateLocation_Success(t *testing.T) {
 	defer mock.Close()
 
 	mock.ExpectExec("UPDATE file SET").
-		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
 
 	a := New(mock)
-	err = a.UpdateLocation(context.Background(), uuid.New(), uuid.New(), false, 1)
+	err = a.UpdateMetadata(context.Background(), uuid.New(), uuid.New(), false, "name.txt", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
-func TestMock_UpdateLocation_NotFound(t *testing.T) {
+func TestMock_UpdateMetadata_NotFound(t *testing.T) {
 	mock, err := pgxmock.NewPool()
 	if err != nil {
 		t.Fatal(err)
@@ -271,11 +271,11 @@ func TestMock_UpdateLocation_NotFound(t *testing.T) {
 	defer mock.Close()
 
 	mock.ExpectExec("UPDATE file SET").
-		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 0))
 
 	a := New(mock)
-	err = a.UpdateLocation(context.Background(), uuid.New(), uuid.New(), false, 1)
+	err = a.UpdateMetadata(context.Background(), uuid.New(), uuid.New(), false, "name.txt", 1)
 	if !errors.Is(err, model.ErrDocumentNotFound) {
 		t.Errorf("expected ErrDocumentNotFound, got %v", err)
 	}
@@ -320,7 +320,7 @@ func TestMock_UpdateFile_DBError(t *testing.T) {
 	}
 }
 
-func TestMock_UpdateLocation_DBError(t *testing.T) {
+func TestMock_UpdateMetadata_DBError(t *testing.T) {
 	mock, err := pgxmock.NewPool()
 	if err != nil {
 		t.Fatal(err)
@@ -328,11 +328,11 @@ func TestMock_UpdateLocation_DBError(t *testing.T) {
 	defer mock.Close()
 
 	mock.ExpectExec("UPDATE file SET").
-		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnError(errors.New("connection reset"))
 
 	a := New(mock)
-	err = a.UpdateLocation(context.Background(), uuid.New(), uuid.New(), false, 1)
+	err = a.UpdateMetadata(context.Background(), uuid.New(), uuid.New(), false, "name.txt", 1)
 	if err == nil {
 		t.Fatal("expected error")
 	}

--- a/internal/adapter/outbound/alkemiodb/adapter_mock_test.go
+++ b/internal/adapter/outbound/alkemiodb/adapter_mock_test.go
@@ -252,12 +252,17 @@ func TestMock_UpdateMetadata_Success(t *testing.T) {
 	}
 	defer mock.Close()
 
+	// Param order in UpdateDocumentMetadata: $1=id, $2=storageBucketId,
+	// $3=temporaryLocation, $4=displayName, $5=updatedDate, $6=version.
+	// Pin everything except updatedDate (timestamp computed in adapter).
+	docID := uuid.New()
+	bucketID := uuid.New()
 	mock.ExpectExec("UPDATE file SET").
-		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WithArgs(uuidToPgx(docID), uuidToPgx(bucketID), false, "name.txt", pgxmock.AnyArg(), int32(1)).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
 
 	a := New(mock)
-	err = a.UpdateMetadata(context.Background(), uuid.New(), uuid.New(), false, "name.txt", 1)
+	err = a.UpdateMetadata(context.Background(), docID, bucketID, false, "name.txt", 1)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/adapter/outbound/alkemiodb/adapter_test.go
+++ b/internal/adapter/outbound/alkemiodb/adapter_test.go
@@ -230,17 +230,18 @@ func TestCountByExternalID(t *testing.T) {
 	}
 }
 
-func TestUpdateLocation(t *testing.T) {
+func TestUpdateMetadata(t *testing.T) {
 	pool := testPool(t)
 	defer pool.Close()
 	a := New(pool)
 
 	var id, bucketID [16]byte
 	var tempLoc bool
+	var displayName string
 	var version int32
 	err := pool.QueryRow(context.Background(),
-		`SELECT id, "storageBucketId", "temporaryLocation", version FROM file LIMIT 1`,
-	).Scan(&id, &bucketID, &tempLoc, &version)
+		`SELECT id, "storageBucketId", "temporaryLocation", "displayName", version FROM file LIMIT 1`,
+	).Scan(&id, &bucketID, &tempLoc, &displayName, &version)
 	if err != nil {
 		t.Skip("no documents")
 	}
@@ -248,13 +249,13 @@ func TestUpdateLocation(t *testing.T) {
 	origBucket := uuid.UUID(bucketID)
 
 	// Update with current version (optimistic lock)
-	err = a.UpdateLocation(context.Background(), docID, origBucket, !tempLoc, int(version))
+	err = a.UpdateMetadata(context.Background(), docID, origBucket, !tempLoc, displayName, int(version))
 	if err != nil {
-		t.Fatalf("UpdateLocation: %v", err)
+		t.Fatalf("UpdateMetadata: %v", err)
 	}
 	defer func() {
 		// Restore with incremented version
-		_ = a.UpdateLocation(context.Background(), docID, origBucket, tempLoc, int(version+1))
+		_ = a.UpdateMetadata(context.Background(), docID, origBucket, tempLoc, displayName, int(version+1))
 	}()
 
 	doc, _ := a.GetByID(context.Background(), docID)
@@ -263,12 +264,12 @@ func TestUpdateLocation(t *testing.T) {
 	}
 }
 
-func TestUpdateLocation_NotFound(t *testing.T) {
+func TestUpdateMetadata_NotFound(t *testing.T) {
 	pool := testPool(t)
 	defer pool.Close()
 	a := New(pool)
 
-	err := a.UpdateLocation(context.Background(), uuid.New(), uuid.New(), false, 1)
+	err := a.UpdateMetadata(context.Background(), uuid.New(), uuid.New(), false, "name.txt", 1)
 	if !errors.Is(err, model.ErrDocumentNotFound) {
 		t.Errorf("expected ErrDocumentNotFound, got %v", err)
 	}

--- a/internal/adapter/outbound/alkemiodb/queries/document.sql.go
+++ b/internal/adapter/outbound/alkemiodb/queries/document.sql.go
@@ -212,25 +212,35 @@ func (q *Queries) UpdateDocumentFile(ctx context.Context, arg UpdateDocumentFile
 	return result.RowsAffected(), nil
 }
 
-const updateDocumentLocation = `-- name: UpdateDocumentLocation :execrows
+const updateDocumentMetadata = `-- name: UpdateDocumentMetadata :execrows
 UPDATE file
-SET "storageBucketId" = $2, "temporaryLocation" = $3, "updatedDate" = $4, version = version + 1
-WHERE id = $1 AND version = $5
+SET "storageBucketId"    = $2,
+    "temporaryLocation"  = $3,
+    "displayName"        = $4,
+    "updatedDate"        = $5,
+    version              = version + 1
+WHERE id = $1 AND version = $6
 `
 
-type UpdateDocumentLocationParams struct {
+type UpdateDocumentMetadataParams struct {
 	ID                pgtype.UUID        `json:"id"`
 	StorageBucketId   pgtype.UUID        `json:"storageBucketId"`
 	TemporaryLocation bool               `json:"temporaryLocation"`
+	DisplayName       string             `json:"displayName"`
 	UpdatedDate       pgtype.Timestamptz `json:"updatedDate"`
 	Version           int32              `json:"version"`
 }
 
-func (q *Queries) UpdateDocumentLocation(ctx context.Context, arg UpdateDocumentLocationParams) (int64, error) {
-	result, err := q.db.Exec(ctx, updateDocumentLocation,
+// Updates the mutable metadata fields (storageBucketId, temporaryLocation,
+// displayName) atomically with optimistic locking. Caller fills unchanged
+// fields with their current values. mimeType, externalID, size are not
+// mutable through this query — they change only via UpdateDocumentFile.
+func (q *Queries) UpdateDocumentMetadata(ctx context.Context, arg UpdateDocumentMetadataParams) (int64, error) {
+	result, err := q.db.Exec(ctx, updateDocumentMetadata,
 		arg.ID,
 		arg.StorageBucketId,
 		arg.TemporaryLocation,
+		arg.DisplayName,
 		arg.UpdatedDate,
 		arg.Version,
 	)

--- a/internal/domain/port/document_repo.go
+++ b/internal/domain/port/document_repo.go
@@ -14,7 +14,7 @@ type DocumentRepo interface {
 	FindByExternalIDAndBucket(ctx context.Context, externalID string, storageBucketID uuid.UUID) (model.Document, error)
 	Create(ctx context.Context, doc model.Document) (uuid.UUID, error)
 	UpdateFile(ctx context.Context, id uuid.UUID, externalID, mimeType string, size int) error
-	UpdateLocation(ctx context.Context, id uuid.UUID, storageBucketID uuid.UUID, temporaryLocation bool, version int) error
+	UpdateMetadata(ctx context.Context, id uuid.UUID, storageBucketID uuid.UUID, temporaryLocation bool, displayName string, version int) error
 	Delete(ctx context.Context, id uuid.UUID) (model.DeletedDocument, error)
 	CountByExternalID(ctx context.Context, externalID string) (int, error)
 }

--- a/internal/domain/service/file_service.go
+++ b/internal/domain/service/file_service.go
@@ -342,10 +342,19 @@ func (s *FileService) StoreAndLink(ctx context.Context, documentID uuid.UUID, co
 	}, nil
 }
 
-// UpdateDocumentLocation updates the storage bucket and temporary location flag.
-// Uses optimistic locking via the version column to prevent concurrent overwrites.
-func (s *FileService) UpdateDocumentLocation(ctx context.Context, documentID uuid.UUID, storageBucketID uuid.UUID, temporaryLocation bool, version int) (*model.Document, error) {
-	err := s.Repo.UpdateLocation(ctx, documentID, storageBucketID, temporaryLocation, version)
+// UpdateDocumentMetadata updates the mutable metadata fields (storage bucket,
+// temporary-location flag, display name) atomically. The handler reads the
+// current row first and fills any fields the caller didn't supply, so this
+// method always overwrites all three columns. Uses optimistic locking via
+// the version column.
+//
+// mimeType, externalID, and size are not mutable through this method — they
+// change only via StoreAndLink (replace content). Callers that rename a
+// document are responsible for keeping displayName's extension consistent
+// with the (immutable) mimeType; this service does not enforce extension
+// matching.
+func (s *FileService) UpdateDocumentMetadata(ctx context.Context, documentID uuid.UUID, storageBucketID uuid.UUID, temporaryLocation bool, displayName string, version int) (*model.Document, error) {
+	err := s.Repo.UpdateMetadata(ctx, documentID, storageBucketID, temporaryLocation, displayName, version)
 	if err != nil {
 		// Version mismatch returns ErrDocumentNotFound (0 rows); translate to ErrConflict
 		if errors.Is(err, model.ErrDocumentNotFound) {

--- a/internal/domain/service/file_service_test.go
+++ b/internal/domain/service/file_service_test.go
@@ -62,7 +62,7 @@ func (m *mockRepo) Create(_ context.Context, doc model.Document) (uuid.UUID, err
 func (m *mockRepo) UpdateFile(_ context.Context, _ uuid.UUID, _, _ string, _ int) error {
 	return m.updateErr
 }
-func (m *mockRepo) UpdateLocation(_ context.Context, _ uuid.UUID, _ uuid.UUID, _ bool, _ int) error {
+func (m *mockRepo) UpdateMetadata(_ context.Context, _ uuid.UUID, _ uuid.UUID, _ bool, _ string, _ int) error {
 	return m.updateErr
 }
 func (m *mockRepo) Delete(_ context.Context, _ uuid.UUID) (model.DeletedDocument, error) {
@@ -458,7 +458,7 @@ func (m *mockRepoRace) Create(_ context.Context, _ model.Document) (uuid.UUID, e
 func (m *mockRepoRace) UpdateFile(_ context.Context, _ uuid.UUID, _, _ string, _ int) error {
 	return nil
 }
-func (m *mockRepoRace) UpdateLocation(_ context.Context, _ uuid.UUID, _ uuid.UUID, _ bool, _ int) error {
+func (m *mockRepoRace) UpdateMetadata(_ context.Context, _ uuid.UUID, _ uuid.UUID, _ bool, _ string, _ int) error {
 	return nil
 }
 func (m *mockRepoRace) Delete(_ context.Context, _ uuid.UUID) (model.DeletedDocument, error) {
@@ -754,7 +754,7 @@ func (m *copyRaceRepo) Create(_ context.Context, _ model.Document) (uuid.UUID, e
 func (m *copyRaceRepo) UpdateFile(_ context.Context, _ uuid.UUID, _, _ string, _ int) error {
 	return nil
 }
-func (m *copyRaceRepo) UpdateLocation(_ context.Context, _ uuid.UUID, _ uuid.UUID, _ bool, _ int) error {
+func (m *copyRaceRepo) UpdateMetadata(_ context.Context, _ uuid.UUID, _ uuid.UUID, _ bool, _ string, _ int) error {
 	return nil
 }
 func (m *copyRaceRepo) Delete(_ context.Context, _ uuid.UUID) (model.DeletedDocument, error) {
@@ -843,7 +843,7 @@ func TestStoreAndLink_DBFails_DoesNotDeleteBlob(t *testing.T) {
 	}
 }
 
-func TestUpdateDocumentLocation_Happy(t *testing.T) {
+func TestUpdateDocumentMetadata_Happy(t *testing.T) {
 	docID := uuid.New()
 	newBucket := uuid.New()
 	svc := &FileService{Logger: nopLogger,
@@ -854,7 +854,7 @@ func TestUpdateDocumentLocation_Happy(t *testing.T) {
 		}},
 	}
 
-	updated, err := svc.UpdateDocumentLocation(context.Background(), docID, newBucket, false, 1)
+	updated, err := svc.UpdateDocumentMetadata(context.Background(), docID, newBucket, false, "renamed.txt", 1)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -863,18 +863,18 @@ func TestUpdateDocumentLocation_Happy(t *testing.T) {
 	}
 }
 
-func TestUpdateDocumentLocation_NotFound(t *testing.T) {
+func TestUpdateDocumentMetadata_NotFound(t *testing.T) {
 	svc := &FileService{Logger: nopLogger,
 		Repo: &mockRepo{updateErr: errors.New("not found")},
 	}
 
-	_, err := svc.UpdateDocumentLocation(context.Background(), uuid.New(), uuid.New(), false, 1)
+	_, err := svc.UpdateDocumentMetadata(context.Background(), uuid.New(), uuid.New(), false, "name.txt", 1)
 	if err == nil {
 		t.Fatal("expected error for not found")
 	}
 }
 
-func TestUpdateDocumentLocation_UpdateFails(t *testing.T) {
+func TestUpdateDocumentMetadata_UpdateFails(t *testing.T) {
 	svc := &FileService{Logger: nopLogger,
 		Repo: &mockRepo{
 			doc:       model.Document{ID: uuid.New()},
@@ -882,7 +882,7 @@ func TestUpdateDocumentLocation_UpdateFails(t *testing.T) {
 		},
 	}
 
-	_, err := svc.UpdateDocumentLocation(context.Background(), uuid.New(), uuid.New(), false, 1)
+	_, err := svc.UpdateDocumentMetadata(context.Background(), uuid.New(), uuid.New(), false, "name.txt", 1)
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -1082,7 +1082,7 @@ func TestStoreAndLink_KeepsOldBlobWhenShared(t *testing.T) {
 	}
 }
 
-func TestUpdateDocumentLocation_VersionConflict(t *testing.T) {
+func TestUpdateDocumentMetadata_VersionConflict(t *testing.T) {
 	svc := &FileService{Logger: nopLogger,
 		Repo: &mockRepo{
 			doc:       model.Document{ID: uuid.New(), Version: 5},
@@ -1090,7 +1090,7 @@ func TestUpdateDocumentLocation_VersionConflict(t *testing.T) {
 		},
 	}
 
-	_, err := svc.UpdateDocumentLocation(context.Background(), uuid.New(), uuid.New(), false, 3)
+	_, err := svc.UpdateDocumentMetadata(context.Background(), uuid.New(), uuid.New(), false, "name.txt", 3)
 	if err == nil {
 		t.Fatal("expected error for version conflict")
 	}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -282,19 +282,19 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/http.errorResponse'
+                $ref: '#/components/schemas/source-document-not-found'
           description: Not Found
         "409":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/http.errorResponse'
+                $ref: '#/components/schemas/skipDedup-requested-but-a-row-with-this-content-already-exists-in-the-destination-bucket'
           description: Conflict
         "500":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/http.errorResponse'
+                $ref: '#/components/schemas/internal-error'
           description: Internal Server Error
       tags:
         - /internal

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -114,17 +114,18 @@ components:
       type: object
     http.UpdateDocumentRequest:
       properties:
+        displayName:
+          type: string
         storageBucketId:
           format: uuid
           type: string
         temporaryLocation:
           type: boolean
-      required:
-        - storageBucketId
-        - temporaryLocation
       type: object
     http.UpdateDocumentResponse:
       properties:
+        displayName:
+          type: string
         id:
           type: string
         storageBucketId:
@@ -135,6 +136,7 @@ components:
         - id
         - storageBucketId
         - temporaryLocation
+        - displayName
       type: object
     http.errorResponse:
       properties:


### PR DESCRIPTION
## Summary

- `PATCH /internal/file/{id}` now accepts an optional `displayName` alongside `storageBucketId` and `temporaryLocation`. At least one of the three must be present; omitted fields fall through unchanged.
- Validation (at the HTTP edge): rejects empty/whitespace-only, >512 bytes (matches the `VARCHAR(512)` column), `/` or `\\`, and control characters (`<0x20` or DEL). `mimeType` stays immutable on this endpoint — callers renaming a file are responsible for keeping the extension consistent. `displayName` is not part of any uniqueness/dedup index, so renames never conflict at the DB level.
- Plumbing rename: `UpdateDocumentLocation` → `UpdateDocumentMetadata` end-to-end (SQL, port, service, adapter) since the call now writes three fields, not just location.
- Driven by Alkemio server's CollaboraDocument rename flow (server PR #5970): the editor title bar and download dialog currently stay stale because the file row's name doesn't track Alkemio-side renames. Server-side wiring is out of scope for this PR.

## Test plan

- [x] `go test ./internal/...` — all green
- [x] `golangci-lint run` — clean
- [x] `make openapi` — `openapi.yaml` picks up `DisplayName` on `UpdateDocumentRequest`/`UpdateDocumentResponse`
- [x] New HTTP tests: happy rename, idempotent rename, combined PATCH, 512-byte boundary accepted, validation rejections for all rules above
- [x] Existing service + adapter tests updated for the new signature; mock repo captures `UpdateMetadata` args so handler→repo propagation is observable
- [ ] Manual verify in dev once the server-side rename wiring (separate PR) lands

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PATCH now supports optional displayName; responses include displayName. PATCH accepts partial updates (at least one of storageBucketId, temporaryLocation, displayName).

* **Bug Fixes**
  * Duplicate-key DB errors surfaced as HTTP 409; optimistic-lock behavior preserved.

* **Validation**
  * displayName validated (non-empty trimmed, max 512 bytes, no path separators or control chars); same rules on create.
  * PATCH, copy and create endpoints reject unknown fields and trailing JSON.

* **Documentation**
  * OpenAPI updated for optional PATCH fields and displayName in responses.

* **Tests**
  * Expanded tests for displayName, validation boundaries, decoder hardening, error mapping, and update semantics.

* **Chores**
  * Added .claude/ to .gitignore.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->