### PR TITLE
chore: link CLAUDE.md to agents-hq

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,11 @@
 # Alkemio File Service (Go)
 
+> **Workspace context.** This repo is part of the Alkemio polyrepo at
+> [alkem-io/alkemio-workspace](https://github.com/alkem-io/alkemio-workspace).
+> Cross-repo (vertical) feature specs live there under `specs/NNN-*/`. When
+> working on a `feat/NNN-...` branch in this repo, the matching workspace
+> spec is the single source of truth.
+
 Go microservice replacing the existing TypeScript file-service. Serves
 as the universal file I/O gateway for the Alkemio platform — handles
 file read, write, delete, and existence checks with pluggable storage

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # Alkemio File Service (Go)
 
 > **Workspace context.** This repo is part of the Alkemio polyrepo at
-> [alkem-io/alkemio-workspace](https://github.com/alkem-io/alkemio-workspace).
+> [alkem-io/agents-hq](https://github.com/alkem-io/agents-hq).
 > Cross-repo (vertical) feature specs live there under `specs/NNN-*/`. When
 > working on a `feat/NNN-...` branch in this repo, the matching workspace
 > spec is the single source of truth.


### PR DESCRIPTION
Adds a small **Workspace context** blockquote to `CLAUDE.md` so future Claude
sessions opened in this repo know that cross-repo (vertical) feature specs
live in [`alkem-io/alkemio-workspace`](https://github.com/alkem-io/alkemio-workspace).

No behaviour change. Documentation only.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>