### PR TITLE
docs(specs): backfill post-review deltas for specs 019/020

### DIFF
--- a/specs/019-preserve-mime-on-edit/data-model.md
+++ b/specs/019-preserve-mime-on-edit/data-model.md
@@ -61,8 +61,8 @@ Relabeled rows leave the suspect set ⇒ the job is idempotent across boots.
 
 | Method | Query | Notes |
 |---|---|---|
-| `ListSuspectMimeRows(ctx)` | `SELECT id, "displayName", "mimeType", size, "externalID" FROM file WHERE "mimeType" = ANY($generics) AND lower("displayName") ~ '\.(docx|xlsx|pptx|odt|ods|odp)$'` | sqlc-generated |
-| `UpdateMimeType(ctx, id, mimeType)` | single-column `UPDATE … SET "mimeType" = $2, "updatedDate" = now() WHERE id = $1` | narrow on purpose (research R6) |
+| `ListByMimeTypes(ctx, mimeTypes)` | `SELECT id, "externalID", "mimeType", size, "displayName" FROM file WHERE "mimeType" = ANY($1::text[])` | sqlc-generated; office-extension filtering happens in the domain via `OfficeMIMEForName` so the office vocabulary stays single-sourced (shipped delta vs the original SQL-regex design) |
+| `UpdateMimeType(ctx, id, expectedExternalID, mimeType) (bool, error)` | compare-and-set: `UPDATE … SET "mimeType" = $2, "updatedDate" = now() WHERE id = $1 AND "externalID" = $4` | CAS guard added in review (PR #29): a Replace landing between the repair scan and the relabel already wrote the correct type for the *new* content — the stale-blob relabel must lose that race silently (false return = skip, not error) |
 
 ## Validation rules (from FRs)
 

--- a/specs/019-preserve-mime-on-edit/data-model.md
+++ b/specs/019-preserve-mime-on-edit/data-model.md
@@ -62,7 +62,7 @@ Relabeled rows leave the suspect set ⇒ the job is idempotent across boots.
 | Method | Query | Notes |
 |---|---|---|
 | `ListByMimeTypes(ctx, mimeTypes)` | `SELECT id, "externalID", "mimeType", size, "displayName" FROM file WHERE "mimeType" = ANY($1::text[])` | sqlc-generated; office-extension filtering happens in the domain via `OfficeMIMEForName` so the office vocabulary stays single-sourced (shipped delta vs the original SQL-regex design) |
-| `UpdateMimeType(ctx, id, expectedExternalID, mimeType) (bool, error)` | compare-and-set: `UPDATE … SET "mimeType" = $2, "updatedDate" = now() WHERE id = $1 AND "externalID" = $4` | CAS guard added in review (PR #29): a Replace landing between the repair scan and the relabel already wrote the correct type for the *new* content — the stale-blob relabel must lose that race silently (false return = skip, not error) |
+| `UpdateMimeType(ctx, id, expectedExternalID, mimeType) (bool, error)` | compare-and-set: `UPDATE file SET "mimeType" = $2, "updatedDate" = $3, version = version + 1 WHERE id = $1 AND "externalID" = $4` — the adapter supplies `$3 = now()`, so the port carries three logical args | CAS guard added in review (PR #29): a Replace landing between the repair scan and the relabel already wrote the correct type for the *new* content — the stale-blob relabel must lose that race silently (false return = skip, not error) |
 
 ## Validation rules (from FRs)
 

--- a/specs/019-preserve-mime-on-edit/research.md
+++ b/specs/019-preserve-mime-on-edit/research.md
@@ -94,9 +94,11 @@ reporting honestly.
 ## R6 — Repair job delivery & office-MIME vocabulary
 
 **Decision**: A goroutine launched from `cmd/server/app.go` after DB connect, running
-once per boot; suspect rows selected by SQL (`mimeType` ∈ generic set AND lowercased
-`displayName` LIKE one of the office extensions), content verified (non-empty + `PK`
-zip magic) before relabeling via an `UpdateMimeType` repo method. The
+once per boot; suspect rows selected by SQL on generic MIME alone, with the
+office-extension check applied in the domain via `OfficeMIMEForName`
+(single-sourced vocabulary — see the post-review delta below), content
+verified (non-empty + `PK` zip magic) before relabeling via the
+`UpdateMimeType` repo method. The
 extension↔canonical-MIME map lives once in `internal/domain/model/mime.go` covering
 OOXML (`.docx/.xlsx/.pptx`) and OpenDocument (`.odt/.ods/.odp`) — the formats the
 Collabora flow stores (acc data shows all of `presentationml`, `wordprocessingml`,
@@ -129,8 +131,9 @@ review and are authoritative as shipped:
    job skips the row (regression test
    `TestRunMimeRepair_ConcurrentReplaceLosesGuardSkipsRelabel`).
 2. **Suspect scan splits SQL and domain filtering.** SQL selects by generic
-   MIME only (`ListDocumentsByMimeTypes`); the office-extension check runs in
-   the domain via `model.OfficeMIMEForName`, keeping the office vocabulary
+   MIME only — port method `ListByMimeTypes`, backed by the sqlc query
+   `ListDocumentsByMimeTypes`; the office-extension check runs in the domain
+   via `model.OfficeMIMEForName`, keeping the office vocabulary
    single-sourced (constitution VIII) instead of duplicating it in a SQL
    regex.
 3. **Outcome counters live at the adapter.** The domain emits structured

--- a/specs/019-preserve-mime-on-edit/research.md
+++ b/specs/019-preserve-mime-on-edit/research.md
@@ -96,7 +96,7 @@ reporting honestly.
 **Decision**: A goroutine launched from `cmd/server/app.go` after DB connect, running
 once per boot; suspect rows selected by SQL (`mimeType` ∈ generic set AND lowercased
 `displayName` LIKE one of the office extensions), content verified (non-empty + `PK`
-zip magic) before relabeling via a narrow `UpdateMimeType` repo method. The
+zip magic) before relabeling via an `UpdateMimeType` repo method. The
 extension↔canonical-MIME map lives once in `internal/domain/model/mime.go` covering
 OOXML (`.docx/.xlsx/.pptx`) and OpenDocument (`.odt/.ods/.odp`) — the formats the
 Collabora flow stores (acc data shows all of `presentationml`, `wordprocessingml`,
@@ -115,3 +115,25 @@ clarification (would make the fix cross-repo). (b) Manual SQL — rejected in
 clarification (relies on an operator per environment). (c) Blocking startup until
 repair completes — rejected: a long storage read loop would delay readiness; the
 job is independent of request serving.
+
+## Post-review deltas (backfilled 2026-06-12 after PR #29 merged)
+
+Three implementation facts diverged from the text above during CodeRabbit
+review and are authoritative as shipped:
+
+1. **Repair relabel is compare-and-set.** `UpdateMimeType(ctx, id,
+   expectedExternalID, mimeType) (bool, error)` only applies while the row's
+   `externalID` still equals the blob the repair job sniffed. The repair
+   goroutine runs concurrently with request serving, so a Replace landing in
+   the scan→relabel window must win: the guard failing returns false and the
+   job skips the row (regression test
+   `TestRunMimeRepair_ConcurrentReplaceLosesGuardSkipsRelabel`).
+2. **Suspect scan splits SQL and domain filtering.** SQL selects by generic
+   MIME only (`ListDocumentsByMimeTypes`); the office-extension check runs in
+   the domain via `model.OfficeMIMEForName`, keeping the office vocabulary
+   single-sourced (constitution VIII) instead of duplicating it in a SQL
+   regex.
+3. **Outcome counters live at the adapter.** The domain emits structured
+   logs and reports the outcome on `StoredFile.ReplaceOutcome`; the HTTP
+   adapter increments `content_replace_outcomes_total` (hexagonal rule — the
+   domain never imports adapter metrics).

--- a/specs/020-stream-uploads/contracts/ingest-contracts.md
+++ b/specs/020-stream-uploads/contracts/ingest-contracts.md
@@ -17,6 +17,12 @@
   dimensions exceed `IMAGE_PIXEL_BUDGET`.
 - Stalled uploads (no bytes for `UPLOAD_IDLE_TIMEOUT_MS`) are aborted; the
   client observes a connection error, the service counts `stalled`.
+- **Metadata field limit** (added in review, PR #31): each non-file
+  multipart field is capped at 16 KiB — the largest legitimate value (a
+  long `allowedMimeTypes` list) is ~2.5 KiB. An oversized field is
+  **rejected with 400** naming the field, never silently truncated (a
+  truncated value would parse as a *different* request); the already-staged
+  file part is aborted (FR-006).
 - Success responses byte-for-byte unchanged.
 
 ### PUT /internal/file/{id}/content (replace)

--- a/specs/020-stream-uploads/data-model.md
+++ b/specs/020-stream-uploads/data-model.md
@@ -61,7 +61,7 @@ of today's `ProcessResult` for the streaming path; orientation-aware
 
 | Env | Default | Governs |
 |---|---|---|
-| `MAX_UPLOAD_SIZE` | 33554432 (32 MiB) | incremental stream cap (FR-005) |
+| `MAX_UPLOAD_SIZE` | 33554432 (32 MiB) | incremental stream cap (FR-005); values above 1073741824 (1 GiB, the validated ceiling) are rejected at startup |
 | `UPLOAD_IDLE_TIMEOUT_MS` | 30000 | progress idle abort (FR-009) |
 | `IMAGE_PIXEL_BUDGET` | 100000000 (100 MP) | decode guard (FR-010) |
 | `VIPS_STREAM_DISC_THRESHOLD` | library default (100 MB) | decoded-frame RAM→scratch spill |

--- a/specs/020-stream-uploads/research.md
+++ b/specs/020-stream-uploads/research.md
@@ -178,3 +178,18 @@ compiling: its `TranscodeStream` is a pass-through copy.
 **Ops note (for the deploy/PR body)**: scratch dir needs an emptyDir mount
 sized for `concurrent transcodes × disc-threshold-exceeding frames`;
 defaults (os.TempDir, 100 MB threshold) are safe for current traffic.
+
+## Post-review deltas (backfilled 2026-06-12 after PR #31 merged)
+
+1. **R4 addendum — metadata field cap.** Each non-file multipart field is
+   capped at 16 KiB and *rejected* (400, field named) when exceeded — read
+   cap+1 then check, never truncate: a silently-truncated `displayName` or
+   `allowedMimeTypes` would parse as a different request. The already-staged
+   file part is aborted on this path (FR-006); the regression test also
+   asserts the abort.
+2. **FR-005 enforcement.** `MAX_UPLOAD_SIZE` is not merely validated to
+   1 GiB — configuration above the ceiling is rejected at startup, so the
+   knob cannot silently enter unproven territory.
+3. **vips knob ordering.** `imaging.ConfigureStreaming` runs *after*
+   `imaging.New()` (which performs `vips.Startup`); stream knobs set on an
+   uninitialized libvips would be ignored.

--- a/specs/020-stream-uploads/spec.md
+++ b/specs/020-stream-uploads/spec.md
@@ -187,9 +187,11 @@ fallback, EMPTY_CONTENT and MIME_MISMATCH rejections, atomicity).
   exceeding a limit aborts the upload promptly without consuming the
   remainder of the body. The maximum upload size MUST become a configuration
   value, defaulting to the current 32 MiB (no rollout behavior change) and
-  supported — validated — up to 1 GiB; memory cost stays fixed at any
-  setting. Raising the cap in an environment is a config-only operation
-  (paired with the matching ingress limit, an infra-ops concern).
+  supported — validated AND enforced — up to 1 GiB: configuration above the
+  validated ceiling is rejected at startup (shipped delta, PR #31 review).
+  Memory cost stays fixed at any setting. Raising the cap in an environment
+  is a config-only operation (paired with the matching ingress limit, an
+  infra-ops concern).
 - **FR-006**: Ingestion MUST be atomic with respect to permanent storage: an
   upload that fails or is aborted at any point leaves no partial permanent
   object and no document row referencing one; staging artifacts are cleaned


### PR DESCRIPTION
Docs-only. PRs #29 and #31 went through several CodeRabbit triage rounds **after** the last spec↔implementation reconciliation; five shipped design facts never made it back into the spec artifacts. This backfills them so the specs describe what actually shipped:

**019 (`specs/019-preserve-mime-on-edit/`)**
- `UpdateMimeType` is a **compare-and-set** on `externalID` (repair job racing a concurrent Collabora save must lose silently) — data-model table + research addendum
- Suspect scan: SQL filters generic MIME only; office-extension matching happens in the domain (`OfficeMIMEForName`) — single-sourced vocabulary
- Outcome counters increment at the HTTP adapter from `StoredFile.ReplaceOutcome` (hexagonal), domain emits logs only

**020 (`specs/020-stream-uploads/`)**
- FR-005: the 1 GiB ceiling is **enforced at startup**, not merely test-validated — spec + config table
- Ingest contract: 16 KiB per-metadata-field cap, **reject-not-truncate** (400 naming the field, staged file aborted) — the contract gap CodeRabbit asked to document

No code changes; gates unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MIME type is preserved across content edits; relabeling of mislabeled office files is limited and will skip safely if the file changed concurrently.
  * Multipart metadata fields are limited to 16 KiB; requests exceeding this are rejected with a 400 naming the offending field and the file upload is aborted.

* **Documentation**
  * Upload size ceiling clarified: supported maximum is 1 GiB and higher config values are rejected at startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->