### PR TITLE
chore: standardize k8s manifests (dev/test deployments + service)

### DIFF
--- a/manifests/26-file-service-deployment-test.yaml
+++ b/manifests/26-file-service-deployment-test.yaml
@@ -98,7 +98,10 @@ spec:
       volumes:
         - name: file-storage
           persistentVolumeClaim:
-            claimName: file-storage-pvc2
+            # TEST tracks the dev-orch base PVC (file-storage-pvc); only the
+            # dev overlay patches this to file-storage-pvc2, so dev and test
+            # differ solely on this claim name.
+            claimName: file-storage-pvc
       affinity:
         podAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/manifests/30-file-service-service.yaml
+++ b/manifests/30-file-service-service.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: alkemio-file-service-service
-
 spec:
   ports:
     - protocol: TCP

--- a/manifests/30-file-service-service.yaml
+++ b/manifests/30-file-service-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: alkemio-file-service-service
+
+spec:
+  ports:
+    - protocol: TCP
+      name: http
+      port: 4003
+      appProtocol: h2c
+  selector:
+    app: alkemio-file-service


### PR DESCRIPTION
## What

Standardize the in-repo `manifests/` set for **file-service** to the
`server` / `client-web` numbered convention, reconciling content against the
authoritative dev-orchestration base + overlays.

### File set

| File | What it mirrors |
|---|---|
| `25-file-service-deployment-dev.yaml` | Refined existing dev deployment. Keeps probes / resources / affinity / PVC. Env vars, probe periods and securityContext reconciled against the dev-orch **base** `11-file-service-deployment.yml`; PVC claim from the dev-orch **dev overlay** (`file-storage-pvc2`). |
| `26-file-service-deployment-test.yaml` | **New.** Identical to dev except the PVC claim — the dev-orch **test** overlay has no deployment patch, so test tracks the base PVC (`file-storage-pvc`). Only the dev overlay patches it to `file-storage-pvc2`. |
| `30-file-service-service.yaml` | **New.** `Service` `alkemio-file-service-service`, selector `app: alkemio-file-service`, port `4003`, `appProtocol: h2c`. Follows `server`'s `30-server-service.yaml` shape; port + appProtocol verified against dev-orch `10-file-service.yml`. |

### What changed in the dev deployment (reconciled with dev-orch base)

- **Image** placeholder aligned with server convention: `rg.nl-ams.scw.cloud/alkemio/alkemio-file-service:latest` (was `alkemio/file-service:v0.1.0`). The deploy workflows overwrite this at deploy time via `kubectl set image`, so the literal value is cosmetic.
- **`AUTH_SERVICE_URL`** and **`LOCAL_STORAGE_PATH`** now sourced from `configMapKeyRef` (alkemio-config) instead of hardcoded literals — matches the authoritative dev-orch base.
- **Probe periods** aligned to base: readiness `periodSeconds: 15`, liveness `periodSeconds: 60` (were 30/30).
- Added the dev-orch base **`securityContext`** (`runAsNonRoot`, `runAsUser/fsGroup: 65532`, `fsGroupChangePolicy`).

### Dev vs test deployment difference

The **only** deployment-level difference dictated by the overlays is the PVC claim name:

- dev → `file-storage-pvc2` (dev overlay patch)
- test → `file-storage-pvc` (dev-orch base; test overlay carries no deployment patch)

### Deliberate deviations / notes

- **No `imagePullSecrets` in-repo.** The dev-orch base pins one, but the reference convention (server/client-web) ships none — the deploy workflows attach `file-service-registry` at deploy time via `kubectl patch`. Kept consistent with that convention.
- **No ingress-routes / middleware.** Per the task, those stay in dev-orchestration only (server ships none in-repo).
- `appProtocol: h2c` retained on the Service (file-service speaks h2c/gRPC) per dev-orch `10-file-service.yml`.

### Validation

- `python3 -c "import yaml,glob; [yaml.safe_load(open(f)) for f in glob.glob('manifests/*.yaml')]"` → all pass.
- `kubectl --dry-run=client apply -f <file>` → all three objects validate.

---

This PR is **independent** of the open workflow/lint PRs (#38 / #39) — it only touches `manifests/`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated file service deployment for development with stronger pod security, config now sourced from cluster config, adjusted health checks, and updated storage reference.
  * Added file service deployment for test with resource limits, affinity hints, health probes and always-pulled image.
  * Added network service to expose the file service on port 4003.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- pr-image-report:start -->
---
### 📦 PR image — test the current state of this PR

```bash
docker pull ghcr.io/alkem-io/file-service:pr-40
```

Current build: `ghcr.io/alkem-io/file-service:pr-40-c4617ce` · `linux/amd64` + `linux/arm64` · index digest `sha256:8cdedc1224d0133afc1b1798c6d9c18c688e49a23a7130e80cf68ce46e6375b6`
<!-- pr-image-report:end -->
