### PR TITLE
fix: accept office docs that sniff as application/zip on create (spec-019 mechanism)

### DIFF
--- a/internal/domain/service/create_mime_test.go
+++ b/internal/domain/service/create_mime_test.go
@@ -1,0 +1,148 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/gabriel-vasile/mimetype"
+	"github.com/google/uuid"
+
+	"github.com/alkem-io/file-service/internal/domain/model"
+)
+
+// Create-path MIME reconciliation (PR #13/#29): an OOXML package whose
+// [Content_Types].xml lands past the 3072-byte sniff window degrades to
+// application/zip, which is not in the bucket allow-list (the bucket lists the
+// concrete office type) → a spurious 415. CompleteUpload now mirrors spec
+// 019's reconcileReplaceMIME on the create allow-list: a generic sniff falls
+// back to the caller's declared office type when that type is allowed.
+//
+// The fixture builder (buildReorderedOOXMLZip) and the pptx/docx/xlsx MIME
+// constants live in replace_mime_test.go and are reused here verbatim — the
+// two paths defend the same degradation, so they share the same fixture.
+
+// Premise: the reordered OOXML fixture must sniff as application/zip under the
+// REAL detector. The service tests below force the sniff via mockProcessor; if
+// the fixture ever stopped degrading, those mocks would be testing nothing —
+// this guard ties the mocked sniff value back to reality on the create side.
+func TestReorderedOOXMLZip_SniffsZip_CreatePremise(t *testing.T) {
+	detected := mimetype.Detect(buildReorderedOOXMLZip(t)).String()
+	if normalizeMIME(detected) != "application/zip" {
+		t.Fatalf("reordered OOXML zip sniffed as %q; the create fallback assumes application/zip", detected)
+	}
+}
+
+// US: a pptx/docx/xlsx that sniffs as application/zip + a declared office MIME
+// that the bucket allows → ACCEPTED, and the persisted document MimeType is
+// the office type, never application/zip.
+func TestCompleteUpload_GenericSniff_FallsBackToDeclaredOffice(t *testing.T) {
+	cases := []struct {
+		name     string
+		declared string
+	}{
+		{"pptx", pptxMime},
+		{"docx", docxMime},
+		{"xlsx", xlsxMime},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			storage := &mockStorage{}
+			repo := &mockRepo{}
+			// mockProcessor forces the sniff to application/zip, reproducing the
+			// past-the-window degradation the premise test proves for real.
+			svc := &FileService{Logger: nopLogger, Repo: repo, Storage: storage,
+				Processor: &mockProcessor{detectMIME: "application/zip"}}
+			input := model.CreateDocumentInput{
+				DisplayName:     "deck.pptx",
+				StorageBucketID: uuid.New(),
+				AuthorizationID: uuid.New(),
+			}
+
+			su, err := svc.StageUpload(context.Background(), bytes.NewReader(buildReorderedOOXMLZip(t)), c.declared)
+			if err != nil {
+				t.Fatal(err)
+			}
+			doc, err := svc.CompleteUpload(context.Background(), su, input, []string{c.declared}, 0)
+			if err != nil {
+				t.Fatalf("CompleteUpload rejected a valid office doc: %v", err)
+			}
+			if doc.MimeType != c.declared {
+				t.Errorf("persisted mime = %q, want %q (must store the office type, not application/zip)", doc.MimeType, c.declared)
+			}
+			if !storage.stages[0].committed {
+				t.Error("stage not committed for an accepted upload")
+			}
+		})
+	}
+}
+
+// Guard: the fallback only fires for a GENUINELY allowed declared type. A
+// zip-sniffing body whose declared type is NOT in the allow-list still 415s —
+// the fix tolerates a missed office signature, it does not turn the allow-list
+// into a suggestion.
+func TestCompleteUpload_GenericSniff_DeclaredNotAllowed_StillRejects(t *testing.T) {
+	storage := &mockStorage{}
+	svc := &FileService{Logger: nopLogger, Repo: &mockRepo{}, Storage: storage,
+		Processor: &mockProcessor{detectMIME: "application/zip"}}
+	input := model.CreateDocumentInput{DisplayName: "x.zip", StorageBucketID: uuid.New(), AuthorizationID: uuid.New()}
+
+	// Declared docx, but the bucket only allows pptx → reject.
+	su, err := svc.StageUpload(context.Background(), bytes.NewReader(buildReorderedOOXMLZip(t)), docxMime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.CompleteUpload(context.Background(), su, input, []string{pptxMime}, 0); !errors.Is(err, ErrUnsupportedMediaType) {
+		t.Fatalf("err = %v, want ErrUnsupportedMediaType", err)
+	}
+	assertSingleAbortedStage(t, storage)
+}
+
+// Guard: a zip-sniffing body with NO declared type (empty Content-Type) and a
+// bucket that does not allow application/zip still 415s — there is nothing
+// trustworthy to fall back to.
+func TestCompleteUpload_GenericSniff_NoDeclared_StillRejects(t *testing.T) {
+	storage := &mockStorage{}
+	svc := &FileService{Logger: nopLogger, Repo: &mockRepo{}, Storage: storage,
+		Processor: &mockProcessor{detectMIME: "application/zip"}}
+	input := model.CreateDocumentInput{DisplayName: "x.bin", StorageBucketID: uuid.New(), AuthorizationID: uuid.New()}
+
+	su, err := svc.StageUpload(context.Background(), bytes.NewReader(buildReorderedOOXMLZip(t)), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.CompleteUpload(context.Background(), su, input, []string{pptxMime}, 0); !errors.Is(err, ErrUnsupportedMediaType) {
+		t.Fatalf("err = %v, want ErrUnsupportedMediaType", err)
+	}
+	assertSingleAbortedStage(t, storage)
+}
+
+// Guard: the transcode path is untouched. When an image is transcoded,
+// su.MimeType (the encoder OUTPUT) differs from su.DetectedMIME (the original
+// input); reconciliation must not run and must not clobber the output MIME.
+// We force a generic DETECTED type and a concrete declared+output type to
+// prove the guard keys on su.MimeType != su.DetectedMIME, not on the sniff
+// alone.
+func TestCompleteUpload_TranscodeOutput_NotReconciled(t *testing.T) {
+	storage := &mockStorage{}
+	svc := &FileService{Logger: nopLogger, Repo: &mockRepo{}, Storage: storage,
+		Processor: &mockProcessor{detectMIME: "application/zip"}}
+	input := model.CreateDocumentInput{DisplayName: "img.jpg", StorageBucketID: uuid.New(), AuthorizationID: uuid.New()}
+
+	su, err := svc.StageUpload(context.Background(), bytes.NewReader([]byte("body")), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Simulate a transcode: the persisted output is image/jpeg while the input
+	// degraded to application/zip. The bucket allows the original detected type.
+	su.MimeType = "image/jpeg"
+	declared := "image/png"
+	su.DeclaredMIME = declared
+	if _, err := svc.CompleteUpload(context.Background(), su, input, []string{"application/zip"}, 0); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if su.MimeType != "image/jpeg" {
+		t.Errorf("transcode output MIME clobbered: got %q, want image/jpeg", su.MimeType)
+	}
+}

--- a/internal/domain/service/ingest.go
+++ b/internal/domain/service/ingest.go
@@ -65,6 +65,13 @@ type StagedUpload struct {
 	// DetectedMIME is the effective input type (declared for empty
 	// content, sniffed otherwise) — the value bucket allow-lists validate.
 	DetectedMIME string
+	// DeclaredMIME is the caller-asserted type (the multipart file part's
+	// Content-Type), normalized. It is consulted only by CompleteUpload, and
+	// only when the sniff degraded to a generic container type: an OOXML
+	// package whose [Content_Types].xml lands past the sniff window sniffs as
+	// application/zip, so the declared office type is the trustworthy one.
+	// This mirrors the replace path's reconcileReplaceMIME (spec 019).
+	DeclaredMIME string
 	Size         int64
 	ImageWidth   *int
 	ImageHeight  *int
@@ -130,6 +137,9 @@ func (s *FileService) StageUpload(ctx context.Context, r io.Reader, declaredMIME
 		return nil, err
 	}
 	su.DetectedMIME = detected
+	// Retain the caller's asserted type for the generic-sniff reconciliation
+	// in CompleteUpload (spec 019 mechanism on the create allow-list).
+	su.DeclaredMIME = normalizeMIME(declaredMIME)
 	return su, nil
 }
 
@@ -208,6 +218,12 @@ func (s *FileService) CompleteUpload(ctx context.Context, su *StagedUpload, inpu
 		for i, m := range allowedMimeTypes {
 			normalized[i] = normalizeMIME(m)
 		}
+		// reconcileCreateMIME may rewrite the detected/persisted type to the
+		// caller's declared office type when the sniff degraded to a generic
+		// container (the [Content_Types].xml-past-the-window case). Run it
+		// before the allow-list check so the office type, not application/zip,
+		// is what gets validated and stored.
+		reconcileCreateMIME(su, normalized)
 		if !slices.Contains(normalized, su.DetectedMIME) {
 			su.Discard()
 			return nil, ErrUnsupportedMediaType
@@ -247,6 +263,45 @@ func (s *FileService) CompleteUpload(ctx context.Context, su *StagedUpload, inpu
 		return s.backfillIfNeeded(ctx, existing), nil
 	}
 	return s.insertDocument(ctx, input, stored, su.MimeType, contentMetadata, su.ImageWidth, su.ImageHeight)
+}
+
+// reconcileCreateMIME applies the spec-019 generic-MIME tolerance to the
+// create allow-list (PR #13/#29). The detector reads only the first
+// sniffPrefixSize (3072) bytes; an OOXML package whose [Content_Types].xml
+// (and ppt/, word/, xl/ markers) sit past that window — e.g. a Collabora or
+// PowerPoint save that leads with docProps/_rels/customXml entries — sniffs
+// as application/zip. The bucket allow-lists the concrete office type, so the
+// degraded sniff would 415 a perfectly valid document.
+//
+// When the sniff is generic (application/zip, application/octet-stream,
+// text/plain — see model.IsGenericMIME) and the caller declared a concrete
+// type that the bucket already allows, that declared type is the trustworthy
+// one: rewrite both the value validated against the allow-list (DetectedMIME)
+// and the value persisted on the document (MimeType) to it. This is the
+// create-path twin of reconcileReplaceMIME's "sniff generic → keep the known
+// type" branch.
+//
+// The transcode path is deliberately untouched: there su.MimeType is the
+// encoder OUTPUT (e.g. image/jpeg) while su.DetectedMIME is the original input
+// (e.g. image/png), so su.MimeType != su.DetectedMIME and the guard below
+// skips reconciliation — a transcoded image's output MIME is never clobbered.
+// For a pptx no transcode runs, so su.MimeType == su.DetectedMIME ==
+// application/zip and the fallback is safe. Keep this guard and the declared-
+// type fallback intact: a strict-lint "simplification" that drops either
+// reintroduces the 415 (PR #29).
+func reconcileCreateMIME(su *StagedUpload, normalizedAllowed []string) {
+	if su.MimeType != su.DetectedMIME {
+		return // transcode happened: persisted output MIME must not change
+	}
+	if !model.IsGenericMIME(su.DetectedMIME) {
+		return // a concrete sniff carries its own identity; trust it
+	}
+	declared := su.DeclaredMIME
+	if declared == "" || !slices.Contains(normalizedAllowed, declared) {
+		return // nothing trustworthy to fall back to
+	}
+	su.DetectedMIME = declared
+	su.MimeType = declared
 }
 
 // logIngest emits the FR-008 structured failure log: outcome derivable from


### PR DESCRIPTION
## Root cause

`POST /internal/document` returned **415 Unsupported Media Type** for valid Office documents (.pptx/.docx/.xlsx) whose zip layout puts `[Content_Types].xml` (and the `ppt/`, `word/`, `xl/` markers) past the **3072-byte** MIME sniff window.

The detector (`gabriel-vasile/mimetype`) reads only the first `sniffPrefixSize` (3072) bytes. A package that leads with large entries — e.g. a real pptx whose zip starts with `docProps/_rels/customXml` — pushes every office signature out of that window, so the content sniffs as `application/zip`. `CompleteUpload` validated that **sniffed** type (`su.DetectedMIME`) against the bucket `allowedMimeTypes`, which lists the *concrete* office MIME, not `application/zip` — so a perfectly valid document was rejected, even though the caller declared the correct Office MIME and it was in `allowedMimeTypes`.

Spec 019 already fixed this degradation for the **replace** path via `reconcileReplaceMIME` (generic sniff → keep the known/declared type). The **create** path lacked the same tolerance.

## Fix

`CompleteUpload` now mirrors spec 019's generic-MIME tolerance on the create allow-list. New helper `reconcileCreateMIME` (in `internal/domain/service/ingest.go`):

- When the sniff is **generic** (`application/zip`, `application/octet-stream`, `text/plain` — via the existing `model.IsGenericMIME` / `genericMIMEs` set from spec 019, not duplicated) **and** the caller's normalized declared MIME is non-empty **and** already present in the normalized `allowedMimeTypes`, it falls back to the declared type before the allow-list check.
- The reconciled type is **also persisted**: the stored document's `MimeType` becomes the declared Office type, not `application/zip`, so the document is later served with the correct `Content-Type`.
- The **transcode path is guarded**: reconciliation only runs when `su.MimeType == su.DetectedMIME` (no transcode). For a transcoded image, `su.MimeType` is the encoder OUTPUT (e.g. `image/jpeg`) while `su.DetectedMIME` is the original input — those differ, so a transcoded image's output MIME is never clobbered. For a pptx no transcode runs (`su.MimeType == su.DetectedMIME == application/zip`), so the fallback is safe.

The caller's declared `Content-Type` is now retained on `StagedUpload.DeclaredMIME` during `StageUpload` so `CompleteUpload` can consult it. A godoc/inline comment references the spec-019 mechanism and the PR #13/#29 context so a future strict-lint or reviewer does not "simplify" the guard away.

## Regression test

`internal/domain/service/create_mime_test.go` (reuses the spec-019 `buildReorderedOOXMLZip` fixture and the `pptxMime`/`docxMime`/`xlsxMime` constants — no real user file):

- **Premise**: the reordered-OOXML fixture sniffs as `application/zip` under the real `mimetype` detector (ties the mocked sniff to reality).
- **Accept**: a zip-sniffing pptx/docx/xlsx + matching declared+allowed MIME → ACCEPTED, persisted `MimeType` is the office type (not `application/zip`), stage committed.
- **Reject (declared not allowed)**: zip sniff, declared docx, bucket allows only pptx → still **415**, stage aborted.
- **Reject (no declared type)**: zip sniff, empty declared MIME, bucket disallows zip → still **415**, stage aborted.
- **Transcode guard**: transcode output MIME (`image/jpeg`) is left intact when the detected input degraded to a generic type.

## Gates

- `go build ./...` and `go build -tags vips ./...` — pass
- `go test ./... -race -count=1` and `go test -tags vips ./... -race -count=1` — pass
- `golangci-lint` (v2.12.2, strict config) default **and** `--build-tags vips` — 0 issues; godoc on the new exported `StagedUpload.DeclaredMIME` field; **no** inline `//nolint`
- `make openapi` → no incremental change attributable to this PR: this is internal logic and does not touch the API surface. The freshly-generated `openapi.yaml` from this branch is byte-identical to the one freshly generated from `develop`. (Any drift in the committed `openapi.yaml` is a pre-existing apispec tool-version mismatch present on `develop`, unrelated to this change.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved document upload handling by correctly identifying office documents (PowerPoint, Word, Excel) when generic types are initially detected, ensuring the declared document type is used for validation and storage when appropriate.

* **Tests**
  * Added comprehensive test coverage for document MIME type detection and reconciliation during upload processing, including edge cases for unsupported document types and transcode scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- pr-image-report:start -->
---
### 📦 PR image — test the current state of this PR

```bash
docker pull ghcr.io/alkem-io/file-service:pr-42
```

Current build: `ghcr.io/alkem-io/file-service:pr-42-8733b84` · `linux/amd64` + `linux/arm64` · index digest `sha256:ad973e65b14cf52acd307892da5341b81b11b7a9f16c6cc3267c7b40245f6200`
<!-- pr-image-report:end -->
