### PR TITLE
fix: recover OOXML MIME from zip central directory on create (no more 415 on reordered office zips)

### DIFF
--- a/internal/adapter/inbound/http/public_handler_test.go
+++ b/internal/adapter/inbound/http/public_handler_test.go
@@ -3,6 +3,7 @@ package http
 import (
 	"bytes"
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -311,6 +312,10 @@ func (s *httpMockStage) Commit() (model.StoredFile, error) {
 	return model.StoredFile{ExternalID: service.ComputeHash(content), Size: len(content), Created: true}, nil
 }
 func (s *httpMockStage) Abort() error { s.aborted = true; return nil }
+func (s *httpMockStage) StagedReaderAt() (io.ReaderAt, int64, error) {
+	b := s.buf.Bytes()
+	return bytes.NewReader(b), int64(len(b)), nil
+}
 
 func (m *mockStorage) OpenStage(_ context.Context) (port.StageWriter, error) {
 	st := &httpMockStage{parent: m}

--- a/internal/adapter/inbound/http/public_handler_test.go
+++ b/internal/adapter/inbound/http/public_handler_test.go
@@ -3,6 +3,7 @@ package http
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -297,9 +298,10 @@ func (m *mockDocRepo) UpdateMimeType(_ context.Context, _ uuid.UUID, _, _ string
 
 // httpMockStage backs mockStorage.OpenStage for handler-level tests (spec 020).
 type httpMockStage struct {
-	parent  *mockStorage
-	buf     bytes.Buffer
-	aborted bool
+	parent    *mockStorage
+	buf       bytes.Buffer
+	committed bool
+	aborted   bool
 }
 
 func (s *httpMockStage) Write(p []byte) (int, error) { return s.buf.Write(p) }
@@ -309,10 +311,18 @@ func (s *httpMockStage) Commit() (model.StoredFile, error) {
 	}
 	content := s.buf.Bytes()
 	s.parent.saved = content
+	s.committed = true
 	return model.StoredFile{ExternalID: service.ComputeHash(content), Size: len(content), Created: true}, nil
 }
 func (s *httpMockStage) Abort() error { s.aborted = true; return nil }
+
+// StagedReaderAt mirrors the real StageWriter contract: the staging artifact is
+// only readable before Commit/Abort (the local adapter's temp file is gone
+// afterwards), so reading post-lifecycle is an error rather than a stale buffer.
 func (s *httpMockStage) StagedReaderAt() (io.ReaderAt, int64, error) {
+	if s.committed || s.aborted {
+		return nil, 0, errors.New("httpMockStage: reader after commit/abort")
+	}
 	b := s.buf.Bytes()
 	return bytes.NewReader(b), int64(len(b)), nil
 }

--- a/internal/adapter/outbound/storage/local/adapter.go
+++ b/internal/adapter/outbound/storage/local/adapter.go
@@ -173,6 +173,22 @@ func (s *stage) Write(p []byte) (int, error) {
 	return n, nil
 }
 
+// StagedReaderAt exposes the staging temp file for random-access inspection
+// before Commit. An *os.File already satisfies io.ReaderAt, and ReadAt is
+// offset-based so the file's seek position is irrelevant — the writer never
+// seeks it. The staged content is flushed to disk (Sync) before the reader is
+// returned. Calling this after Commit or Abort is an error: the temp file no
+// longer exists.
+func (s *stage) StagedReaderAt() (io.ReaderAt, int64, error) {
+	if s.committed || s.aborted {
+		return nil, 0, fmt.Errorf("stage: reader after commit/abort")
+	}
+	if err := s.tmp.Sync(); err != nil {
+		return nil, 0, fmt.Errorf("sync staging file: %w", err)
+	}
+	return s.tmp, int64(s.size), nil
+}
+
 // Commit closes the staging file and publishes it under its content hash.
 // Publish is atomic and never overwrites an existing blob: os.Link creates
 // the content-addressed name in a single step that fails with os.IsExist when

--- a/internal/adapter/outbound/storage/local/adapter_test.go
+++ b/internal/adapter/outbound/storage/local/adapter_test.go
@@ -1,7 +1,9 @@
 package local
 
 import (
+	"bytes"
 	"context"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -317,6 +319,46 @@ func TestStage_CommitPublishesWithCorrectIdentity(t *testing.T) {
 	}
 	if entries := stagingArtifacts(t, dir); len(entries) != 0 {
 		t.Errorf("staging artifact left after Commit: %v", entries)
+	}
+}
+
+func TestStage_StagedReaderAtReturnsStagedBytes(t *testing.T) {
+	dir := t.TempDir()
+	a := New(dir)
+	content := []byte("staged bytes for random-access inspection")
+
+	st, err := a.OpenStage(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.Write(content[:10]); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.Write(content[10:]); err != nil {
+		t.Fatal(err)
+	}
+
+	ra, size, err := st.StagedReaderAt()
+	if err != nil {
+		t.Fatalf("StagedReaderAt: %v", err)
+	}
+	if size != int64(len(content)) {
+		t.Errorf("size = %d, want %d", size, len(content))
+	}
+	got := make([]byte, size)
+	if _, err := ra.ReadAt(got, 0); err != nil && err != io.EOF {
+		t.Fatalf("ReadAt: %v", err)
+	}
+	if !bytes.Equal(got, content) {
+		t.Errorf("staged bytes = %q, want %q", got, content)
+	}
+
+	// After Commit the staging artifact is gone: StagedReaderAt must error.
+	if _, err := st.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := st.StagedReaderAt(); err == nil {
+		t.Error("StagedReaderAt after Commit = nil error, want error")
 	}
 }
 

--- a/internal/domain/port/storage.go
+++ b/internal/domain/port/storage.go
@@ -43,4 +43,11 @@ type StageWriter interface {
 	// Abort destroys the staging artifact. Idempotent; safe after a failed
 	// Commit and after a successful one (no-op then).
 	Abort() error
+	// StagedReaderAt exposes the bytes written so far for random-access
+	// inspection before Commit (e.g. reading a zip central directory). Valid
+	// only after writes complete and before Commit/Abort. The local FS backend
+	// returns the staging temp file; an object-store backend would satisfy this
+	// with ranged reads of the staged object (zip.NewReader uses ReadAt on the
+	// tail, so ranged GETs suffice).
+	StagedReaderAt() (io.ReaderAt, int64, error)
 }

--- a/internal/domain/service/create_ooxml_central_dir_test.go
+++ b/internal/domain/service/create_ooxml_central_dir_test.go
@@ -213,6 +213,55 @@ func TestCompleteUpload_RecoveredOfficeNotAllowedRejected(t *testing.T) {
 	assertSingleAbortedStage(t, storage)
 }
 
+// When StagedReaderAt fails (an infrastructure read error — FS sync, or a
+// future object-store ranged read), OOXML recovery is skipped rather than
+// turned into a hard error: the upload falls through to plain application/zip
+// allow-list validation. An office package whose staged bytes are unreadable is
+// therefore treated as application/zip — accepted when zip is allowed, rejected
+// only by the ordinary allow-list, never by a synthesised inspection error.
+func TestCompleteUpload_StagedReaderErrorSkipsRecovery(t *testing.T) {
+	readErr := errors.New("staged reader unavailable")
+	content := buildOOXMLZipWithMarker(t, "ppt/") // would recover as pptx if readable
+
+	// application/zip allowed: recovery is skipped, content validates as zip.
+	t.Run("zip allowed → accepted as application/zip", func(t *testing.T) {
+		storage := &mockStorage{stageReaderErr: readErr}
+		svc := &FileService{Logger: nopLogger, Repo: &mockRepo{}, Storage: storage, Processor: &mockProcessor{detectMIME: "application/zip"}}
+		su, err := svc.StageUpload(context.Background(), bytes.NewReader(content), "")
+		if err != nil {
+			t.Fatalf("StageUpload: %v", err)
+		}
+		input := model.CreateDocumentInput{DisplayName: "deck.pptx", StorageBucketID: uuid.New(), AuthorizationID: uuid.New()}
+		doc, err := svc.CompleteUpload(context.Background(), su, input, []string{"application/zip"}, 0)
+		if err != nil {
+			t.Fatalf("CompleteUpload: %v, want accepted (recovery skipped, not a hard error)", err)
+		}
+		if doc.MimeType != "application/zip" {
+			t.Errorf("doc.MimeType = %q, want application/zip (recovery skipped on reader error)", doc.MimeType)
+		}
+	})
+
+	// office-only allow-list: recovery skipped, so the unrecovered application/zip
+	// is rejected by the ordinary allow-list — not by an inspection error.
+	t.Run("office-only allow-list → rejected by allow-list", func(t *testing.T) {
+		storage := &mockStorage{stageReaderErr: readErr}
+		svc := &FileService{Logger: nopLogger, Repo: &mockRepo{}, Storage: storage, Processor: &mockProcessor{detectMIME: "application/zip"}}
+		su, err := svc.StageUpload(context.Background(), bytes.NewReader(content), "")
+		if err != nil {
+			t.Fatalf("StageUpload: %v", err)
+		}
+		input := model.CreateDocumentInput{DisplayName: "deck.pptx", StorageBucketID: uuid.New(), AuthorizationID: uuid.New()}
+		doc, err := svc.CompleteUpload(context.Background(), su, input, []string{model.OfficeExtToMIME[".pptx"]}, 0)
+		if !errors.Is(err, ErrUnsupportedMediaType) {
+			t.Fatalf("err = %v, want ErrUnsupportedMediaType (allow-list rejects unrecovered zip)", err)
+		}
+		if doc != nil {
+			t.Errorf("doc = %+v, want nil on rejection", doc)
+		}
+		assertSingleAbortedStage(t, storage)
+	})
+}
+
 // The image-transcode path's persisted MIME is unaffected: when MimeType is the
 // transcode output (≠ DetectedMIME), the zip-recovery gate never fires. We
 // simulate it by leaving DetectedMIME generic but MimeType set to the transcode

--- a/internal/domain/service/create_ooxml_central_dir_test.go
+++ b/internal/domain/service/create_ooxml_central_dir_test.go
@@ -1,0 +1,243 @@
+package service
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/gabriel-vasile/mimetype"
+	"github.com/google/uuid"
+
+	"github.com/alkem-io/file-service/internal/domain/model"
+)
+
+// Create path: recover the canonical OOXML MIME from a reordered office zip's
+// central directory when the 3072-byte front-window sniff has degraded to
+// application/zip ([Content_Types].xml past the window). Regression for the
+// spurious 415 on create. The closed PR #42 trusted the declared MIME; here
+// we instead verify the staged content's central directory.
+
+// buildOOXMLZipWithMarker builds a synthetic OOXML-shaped package whose office
+// marker entries sit *after* an 8 KiB leading entry, so the front-window sniff
+// can only see application/zip (proven by the premise test below). markerDir
+// is the family directory ("ppt/", "word/", "xl/"). The leading entry mirrors
+// the real Collabora trigger: a stored docProps thumbnail (a pptx leading with
+// docProps/_rels/customXml is what surfaced this bug in production).
+func buildOOXMLZipWithMarker(t *testing.T, markerDir string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+
+	hdr := &zip.FileHeader{Name: "docProps/thumbnail.jpeg", Method: zip.Store}
+	f, err := zw.CreateHeader(hdr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	padding := bytes.Repeat([]byte{0xAA, 0x55}, 4096) // 8 KiB, contains no PK marker
+	if _, err := f.Write(padding); err != nil {
+		t.Fatal(err)
+	}
+
+	ct, err := zw.Create("[Content_Types].xml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ct.Write([]byte(`<?xml version="1.0"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"/>`)); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 3; i++ {
+		e, err := zw.Create(fmt.Sprintf("%spart%d.xml", markerDir, i+1))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := e.Write([]byte(`<?xml version="1.0"?><x/>`)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+// buildPlainZip builds a zip with real entries but NO [Content_Types].xml and
+// no office marker directory — a genuine non-office archive. Used to prove the
+// recovery path does not blindly accept a mislabeled zip (the key improvement
+// over the closed PR #42).
+func buildPlainZip(t *testing.T) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+
+	hdr := &zip.FileHeader{Name: "data/blob.bin", Method: zip.Store}
+	f, err := zw.CreateHeader(hdr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write(bytes.Repeat([]byte{0xAA, 0x55}, 4096)); err != nil {
+		t.Fatal(err)
+	}
+	r, err := zw.Create("README.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.Write([]byte("just a plain zip")); err != nil {
+		t.Fatal(err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+// Premise: every fixture must genuinely sniff as application/zip under the real
+// detector, so the create tests prove the recovery path rather than a trivially
+// correct front-window sniff.
+func TestCreateOOXMLFixtures_SniffGeneric(t *testing.T) {
+	fixtures := map[string][]byte{
+		"pptx":     buildOOXMLZipWithMarker(t, "ppt/"),
+		"docx":     buildOOXMLZipWithMarker(t, "word/"),
+		"xlsx":     buildOOXMLZipWithMarker(t, "xl/"),
+		"plainzip": buildPlainZip(t),
+	}
+	for name, content := range fixtures {
+		detected := mimetype.Detect(content).String()
+		if model.NormalizeMIME(detected) != "application/zip" {
+			t.Errorf("%s fixture sniffed as %q, want application/zip (premise of the recovery path)", name, detected)
+		}
+	}
+}
+
+// detectZipOfficeMIME maps each marker family to the canonical office MIME, and
+// rejects a plain zip.
+func TestDetectZipOfficeMIME(t *testing.T) {
+	cases := []struct {
+		name     string
+		content  []byte
+		wantMIME string
+		wantOK   bool
+	}{
+		{"pptx", buildOOXMLZipWithMarker(t, "ppt/"), model.OfficeExtToMIME[".pptx"], true},
+		{"docx", buildOOXMLZipWithMarker(t, "word/"), model.OfficeExtToMIME[".docx"], true},
+		{"xlsx", buildOOXMLZipWithMarker(t, "xl/"), model.OfficeExtToMIME[".xlsx"], true},
+		{"plain zip rejected", buildPlainZip(t), "", false},
+		{"garbage rejected", []byte("not a zip at all"), "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mime, ok := detectZipOfficeMIME(bytes.NewReader(tc.content), int64(len(tc.content)))
+			if ok != tc.wantOK || mime != tc.wantMIME {
+				t.Fatalf("detectZipOfficeMIME = (%q, %v), want (%q, %v)", mime, ok, tc.wantMIME, tc.wantOK)
+			}
+		})
+	}
+}
+
+// completeStagedZip stages content whose front-window sniff is forced to
+// application/zip (the degraded-sniff condition), then completes the upload
+// against allowed. Returns the resulting document and error.
+func completeStagedZip(t *testing.T, content []byte, allowed []string) (*model.Document, *mockStorage, error) {
+	t.Helper()
+	storage := &mockStorage{}
+	repo := &mockRepo{}
+	svc := &FileService{Logger: nopLogger, Repo: repo, Storage: storage, Processor: &mockProcessor{detectMIME: "application/zip"}}
+
+	su, err := svc.StageUpload(context.Background(), bytes.NewReader(content), "")
+	if err != nil {
+		t.Fatalf("StageUpload: %v", err)
+	}
+	if su.DetectedMIME != "application/zip" {
+		t.Fatalf("precondition: DetectedMIME = %q, want application/zip", su.DetectedMIME)
+	}
+	input := model.CreateDocumentInput{DisplayName: "deck.pptx", StorageBucketID: uuid.New(), AuthorizationID: uuid.New()}
+	doc, err := svc.CompleteUpload(context.Background(), su, input, allowed, 0)
+	return doc, storage, err
+}
+
+// Recovered OOXML packages whose office type is allowed are ACCEPTED and the
+// persisted document MIME is the office type, not application/zip.
+func TestCompleteUpload_RecoversOOXMLFromCentralDir(t *testing.T) {
+	cases := []struct {
+		name     string
+		marker   string
+		wantMIME string
+	}{
+		{"pptx", "ppt/", model.OfficeExtToMIME[".pptx"]},
+		{"docx", "word/", model.OfficeExtToMIME[".docx"]},
+		{"xlsx", "xl/", model.OfficeExtToMIME[".xlsx"]},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			content := buildOOXMLZipWithMarker(t, tc.marker)
+			doc, _, err := completeStagedZip(t, content, []string{tc.wantMIME})
+			if err != nil {
+				t.Fatalf("CompleteUpload: %v, want accepted", err)
+			}
+			if doc.MimeType != tc.wantMIME {
+				t.Errorf("doc.MimeType = %q, want %q (content-derived office type, not application/zip)", doc.MimeType, tc.wantMIME)
+			}
+		})
+	}
+}
+
+// A plain non-office zip declared as pptx with an allow-list of [pptx] is still
+// REJECTED: recovery does not invent an office type, so the existing allow-list
+// check rejects the unrecovered application/zip. This is the key improvement
+// over the closed PR #42 (which trusted the declared MIME).
+func TestCompleteUpload_PlainZipDeclaredOfficeRejected(t *testing.T) {
+	content := buildPlainZip(t)
+	doc, storage, err := completeStagedZip(t, content, []string{model.OfficeExtToMIME[".pptx"]})
+	if !errors.Is(err, ErrUnsupportedMediaType) {
+		t.Fatalf("err = %v, want ErrUnsupportedMediaType (mislabeled non-office zip must be rejected)", err)
+	}
+	if doc != nil {
+		t.Errorf("doc = %+v, want nil on rejection", doc)
+	}
+	assertSingleAbortedStage(t, storage)
+}
+
+// An office zip whose recovered type is NOT in the bucket allow-list is
+// REJECTED — recovery feeds the allow-list, it does not bypass it.
+func TestCompleteUpload_RecoveredOfficeNotAllowedRejected(t *testing.T) {
+	content := buildOOXMLZipWithMarker(t, "ppt/") // recovers as pptx
+	doc, storage, err := completeStagedZip(t, content, []string{model.OfficeExtToMIME[".docx"]})
+	if !errors.Is(err, ErrUnsupportedMediaType) {
+		t.Fatalf("err = %v, want ErrUnsupportedMediaType (recovered pptx not in [docx] allow-list)", err)
+	}
+	if doc != nil {
+		t.Errorf("doc = %+v, want nil on rejection", doc)
+	}
+	assertSingleAbortedStage(t, storage)
+}
+
+// The image-transcode path's persisted MIME is unaffected: when MimeType is the
+// transcode output (≠ DetectedMIME), the zip-recovery gate never fires. We
+// simulate it by leaving DetectedMIME generic but MimeType set to the transcode
+// result, mirroring stageContent's image branch.
+func TestCompleteUpload_TranscodePathMIMEUnaffected(t *testing.T) {
+	storage := &mockStorage{}
+	repo := &mockRepo{}
+	svc := &FileService{Logger: nopLogger, Repo: repo, Storage: storage, Processor: &mockProcessor{}}
+
+	// Stage some bytes via a normal pass-through to get a usable stage.
+	su, err := svc.StageUpload(context.Background(), bytes.NewReader([]byte("transcoded jpeg bytes")), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Emulate the image-transcode outcome: DetectedMIME stays the (irrelevant)
+	// sniff, MimeType is the encoder output and differs from DetectedMIME.
+	su.DetectedMIME = "application/zip"
+	su.MimeType = "image/jpeg"
+
+	input := model.CreateDocumentInput{DisplayName: "photo.jpg", StorageBucketID: uuid.New(), AuthorizationID: uuid.New()}
+	doc, err := svc.CompleteUpload(context.Background(), su, input, []string{"application/zip"}, 0)
+	if err != nil {
+		t.Fatalf("CompleteUpload: %v", err)
+	}
+	if doc.MimeType != "image/jpeg" {
+		t.Errorf("doc.MimeType = %q, want image/jpeg (transcode output must not be rewritten by zip recovery)", doc.MimeType)
+	}
+}

--- a/internal/domain/service/file_service_test.go
+++ b/internal/domain/service/file_service_test.go
@@ -1734,6 +1734,17 @@ func (s *mockStage) Abort() error {
 	return nil
 }
 
+// StagedReaderAt exposes the staged bytes for pre-Commit inspection (the zip
+// central-directory recovery path). Backed by a bytes.Reader over the buffer,
+// which is an io.ReaderAt.
+func (s *mockStage) StagedReaderAt() (io.ReaderAt, int64, error) {
+	if s.committed || s.aborted {
+		return nil, 0, errors.New("mockStage: reader after commit/abort")
+	}
+	b := s.buf.Bytes()
+	return bytes.NewReader(b), int64(len(b)), nil
+}
+
 func (m *mockStorage) OpenStage(_ context.Context) (port.StageWriter, error) {
 	if m.openStageErr != nil {
 		return nil, m.openStageErr

--- a/internal/domain/service/file_service_test.go
+++ b/internal/domain/service/file_service_test.go
@@ -155,6 +155,7 @@ type mockStorage struct {
 	openStageErr   error
 	stageWriteErr  error
 	stageCommitErr error
+	stageReaderErr error // StagedReaderAt failure (infra read error, e.g. FS sync / S3 ranged read)
 	stageDedupHit  bool
 	stageDiscard   bool // count writes without buffering (allocation tests)
 	stages         []*mockStage
@@ -1740,6 +1741,9 @@ func (s *mockStage) Abort() error {
 func (s *mockStage) StagedReaderAt() (io.ReaderAt, int64, error) {
 	if s.committed || s.aborted {
 		return nil, 0, errors.New("mockStage: reader after commit/abort")
+	}
+	if s.parent.stageReaderErr != nil {
+		return nil, 0, s.parent.stageReaderErr
 	}
 	b := s.buf.Bytes()
 	return bytes.NewReader(b), int64(len(b)), nil

--- a/internal/domain/service/ingest.go
+++ b/internal/domain/service/ingest.go
@@ -1,12 +1,14 @@
 package service
 
 import (
+	"archive/zip"
 	"bufio"
 	"context"
 	"errors"
 	"fmt"
 	"io"
 	"slices"
+	"strings"
 
 	"go.uber.org/zap"
 
@@ -203,6 +205,25 @@ func (s *FileService) CompleteUpload(ctx context.Context, su *StagedUpload, inpu
 		su.Discard()
 		return nil, ErrPayloadTooLarge
 	}
+
+	// A front-window sniff (3072 bytes) degrades to application/zip when an
+	// OOXML package's [Content_Types].xml lands past that window — the cause
+	// of spurious 415s on reordered office zips (cf. spec 019 / PR #13). When
+	// the sniff is the generic application/zip (and was not overridden by a
+	// transcode, where MimeType is the encoder output), recover the real
+	// OOXML type from the staged file's central directory and validate THAT
+	// against the allow-list below. The su.MimeType == su.DetectedMIME guard
+	// keeps the image-transcode path untouched (images never sniff as zip).
+	if normalizeMIME(su.DetectedMIME) == "application/zip" && su.MimeType == su.DetectedMIME {
+		if ra, size, err := su.stage.StagedReaderAt(); err == nil {
+			if officeMIME, ok := detectZipOfficeMIME(ra, size); ok {
+				su.DetectedMIME = officeMIME // validated against the allow-list below
+				su.MimeType = officeMIME     // persisted as the real office type, not application/zip
+				s.logIngest("recovered office MIME from zip central directory", officeMIME, su.Size, nil)
+			}
+		}
+	}
+
 	if len(allowedMimeTypes) > 0 {
 		normalized := make([]string, len(allowedMimeTypes))
 		for i, m := range allowedMimeTypes {
@@ -247,6 +268,43 @@ func (s *FileService) CompleteUpload(ctx context.Context, su *StagedUpload, inpu
 		return s.backfillIfNeeded(ctx, existing), nil
 	}
 	return s.insertDocument(ctx, input, stored, su.MimeType, contentMetadata, su.ImageWidth, su.ImageHeight)
+}
+
+// detectZipOfficeMIME recovers the canonical OOXML MIME from a staged zip's
+// central directory when the 3072-byte front-window sniff degraded to
+// application/zip (the mechanism behind spurious 415s, cf. spec 019 / PR #13:
+// an office package whose [Content_Types].xml lands past the sniff window).
+// Reads only the central directory (cheap; no full decompression). Returns
+// the office MIME + true for an OOXML package, or "" / false for a plain
+// (non-office) or unreadable zip.
+func detectZipOfficeMIME(ra io.ReaderAt, size int64) (string, bool) {
+	zr, err := zip.NewReader(ra, size)
+	if err != nil {
+		return "", false
+	}
+
+	// An OOXML package is identified by [Content_Types].xml at the root plus
+	// a top-level marker directory naming the family. This mirrors mimetype's
+	// own msoxml heuristic — reliable and parse-free.
+	hasContentTypes := false
+	var ext string
+	for _, f := range zr.File {
+		switch {
+		case f.Name == "[Content_Types].xml":
+			hasContentTypes = true
+		case strings.HasPrefix(f.Name, "ppt/"):
+			ext = ".pptx"
+		case strings.HasPrefix(f.Name, "word/"):
+			ext = ".docx"
+		case strings.HasPrefix(f.Name, "xl/"):
+			ext = ".xlsx"
+		}
+	}
+	if !hasContentTypes || ext == "" {
+		return "", false
+	}
+	mime, ok := model.OfficeExtToMIME[ext]
+	return mime, ok
 }
 
 // logIngest emits the FR-008 structured failure log: outcome derivable from

--- a/internal/domain/service/ingest.go
+++ b/internal/domain/service/ingest.go
@@ -215,7 +215,17 @@ func (s *FileService) CompleteUpload(ctx context.Context, su *StagedUpload, inpu
 	// against the allow-list below. The su.MimeType == su.DetectedMIME guard
 	// keeps the image-transcode path untouched (images never sniff as zip).
 	if normalizeMIME(su.DetectedMIME) == "application/zip" && su.MimeType == su.DetectedMIME {
-		if ra, size, err := su.stage.StagedReaderAt(); err == nil {
+		ra, size, err := su.stage.StagedReaderAt()
+		switch {
+		case err != nil:
+			// An infrastructure read failure (FS sync, or a future object-store
+			// ranged read) is not a verdict on the content: don't treat it as
+			// "not an office package". Recovery is skipped and the upload falls
+			// through to plain application/zip allow-list validation, but log it
+			// so a legitimate office file rejected only because its staged bytes
+			// were unreadable is diagnosable rather than silent.
+			s.logIngest("zip central-directory reader unavailable; skipping OOXML recovery", su.DetectedMIME, su.Size, err)
+		default:
 			if officeMIME, ok := detectZipOfficeMIME(ra, size); ok {
 				su.DetectedMIME = officeMIME // validated against the allow-list below
 				su.MimeType = officeMIME     // persisted as the real office type, not application/zip


### PR DESCRIPTION
## Problem — spurious 415 on create for reordered office zips

The create path sniffs the upload's MIME with `gabriel-vasile/mimetype`, which reads a **3072-byte front window**. OOXML detection relies on seeing `[Content_Types].xml` and a `ppt/`/`word/`/`xl/` marker entry **inside that window**. When an Office package's zip layout pushes those past 3072 bytes — e.g. a `.pptx` that leads with a stored `docProps/_rels/customXml` (or thumbnail) large enough to dominate the front window — the sniff degrades to the generic `application/zip`. That generic type then fails the bucket allow-list and the create returns a spurious **415 Unsupported Media Type**, even though the file is a perfectly valid presentation.

The real trigger in production was a `.pptx` whose archive led with `docProps/_rels/customXml`.

## Fix — verify content via the zip central directory (not the declared MIME)

A prior PR (#42) took the "trust the caller's declared MIME" route and was closed. This PR verifies **content** instead:

When the sniff is the generic `application/zip`, read the **staged file's zip central directory** — the authoritative file table at the tail of the archive — to recover the real OOXML type, validate **that** against the allow-list, and persist it. This:

- correctly **rejects a mislabeled non-office zip** (a plain zip stays `application/zip` and is rejected if zip isn't allowed),
- makes the persisted MIME **content-derived**, not the caller's claim,
- keeps **O(1) memory**: the upload already streams to disk (spec 020 `StageWriter`), and `archive/zip` only reads the central directory plus the small entries it opens — the central directory is a cheap tail read.

## Changes

- **`port.StageWriter`** gains `StagedReaderAt() (io.ReaderAt, int64, error)` for pre-Commit random-access inspection of staged-but-uncommitted content. The local FS backend returns the staging temp file (an `*os.File` is an `io.ReaderAt`); **an object-store backend would satisfy this with ranged reads** — `zip.NewReader` uses `ReadAt` on the tail, so ranged GETs suffice.
- **local adapter** implements `StagedReaderAt` (Sync's the temp file, returns it + bytes-written; errors after Commit/Abort).
- **`CompleteUpload`** recovers + persists the office MIME when `DetectedMIME` is `application/zip`. Gated by `NormalizeMIME(DetectedMIME) == "application/zip" && MimeType == DetectedMIME` so the common path pays nothing and the **image-transcode path is never touched** (its `MimeType` is the encoder output ≠ `DetectedMIME`; images never sniff as zip anyway).
- **`detectZipOfficeMIME`** maps `[Content_Types].xml` + a `ppt/`/`word/`/`xl/` marker dir to the canonical OOXML MIME (mirrors mimetype's own msoxml heuristic; any zip error → not-office).

## Tests

- `pptx`/`docx`/`xlsx` that sniff as `application/zip` + allow-list contains the office type → **accepted**, and the persisted document `MimeType` is the office type (not `application/zip`).
- Premise assertion: the fixtures genuinely sniff as `application/zip` under the **real** mimetype detector, so the tests prove the recovery path (not a trivially-correct sniff).
- A plain non-office zip (entries but no `[Content_Types].xml`/marker) declared as pptx with allow-list `[pptx]` → still **rejected** with `ErrUnsupportedMediaType` (the key improvement over the closed #42 — we don't blindly trust the declared type).
- An office zip whose recovered type is **not** in the allow-list → **rejected**.
- The image-transcode path's persisted MIME is **unaffected**.
- Local-adapter test: `StagedReaderAt` returns the exact staged bytes and errors after Commit.

## Gates

`go build ./...` + `-tags vips`; `go test ./... -race` (default and `-tags vips`); golangci-lint v2.12.2 strict (default and `--build-tags vips`) — 0 issues, godoc on the new exported port method, no inline nolint. `openapi.yaml` unchanged (internal logic only).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Office document detection: OOXML packages (Word/Excel/PowerPoint) are now recovered from generic ZIP uploads by inspecting the ZIP structure, ensuring correct MIME assignment when allowed.
  * Enhanced upload staging with inspection: during upload finalization, you can now access staged bytes via random-access reads prior to commit.

* **Tests**
  * Expanded coverage for OOXML MIME recovery, allow-list validation, and the case where staged inspection fails (recovery is skipped).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- pr-image-report:start -->
---
### 📦 PR image — test the current state of this PR

```bash
docker pull ghcr.io/alkem-io/file-service:pr-43
```

Current build: `ghcr.io/alkem-io/file-service:pr-43-a64274f` · `linux/amd64` + `linux/arm64` · index digest `sha256:b2d406e97fc2db47ab7ca78a262e871740bcd54286d122daa95e34f20881ca9a`
<!-- pr-image-report:end -->
