### PR TITLE
ci: point reusable-workflow callers at alkem-io/github-workflows (org repo)

### DIFF
--- a/.github/workflows/build-deploy-k8s-dev-hetzner.yml
+++ b/.github/workflows/build-deploy-k8s-dev-hetzner.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   deploy:
-    uses: antst/alkemio-github-workflows/.github/workflows/deploy-hetzner.yml@v1
+    uses: alkem-io/github-workflows/.github/workflows/deploy-hetzner.yml@v1
     with:
       environment: dev
       # image / deployment / container / pull-secret names all match the

--- a/.github/workflows/build-deploy-k8s-sandbox-hetzner.yml
+++ b/.github/workflows/build-deploy-k8s-sandbox-hetzner.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   deploy:
-    uses: antst/alkemio-github-workflows/.github/workflows/deploy-hetzner.yml@v1
+    uses: alkem-io/github-workflows/.github/workflows/deploy-hetzner.yml@v1
     with:
       environment: sandbox
       # image / deployment / container / pull-secret names all match the

--- a/.github/workflows/build-deploy-k8s-test-hetzner.yml
+++ b/.github/workflows/build-deploy-k8s-test-hetzner.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   deploy:
-    uses: antst/alkemio-github-workflows/.github/workflows/deploy-hetzner.yml@v1
+    uses: alkem-io/github-workflows/.github/workflows/deploy-hetzner.yml@v1
     with:
       environment: test
       # image / deployment / container / pull-secret names all match the

--- a/.github/workflows/build-push-ghcr-pr.yml
+++ b/.github/workflows/build-push-ghcr-pr.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   image:
-    uses: antst/alkemio-github-workflows/.github/workflows/container-pr.yml@v1
+    uses: alkem-io/github-workflows/.github/workflows/container-pr.yml@v1
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/build-release-docker-hub.yml
+++ b/.github/workflows/build-release-docker-hub.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   release:
-    uses: antst/alkemio-github-workflows/.github/workflows/container-release.yml@v1
+    uses: alkem-io/github-workflows/.github/workflows/container-release.yml@v1
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   ci:
-    uses: antst/alkemio-github-workflows/.github/workflows/go-ci.yml@v1
+    uses: alkem-io/github-workflows/.github/workflows/go-ci.yml@v1
     permissions:
       contents: read
     with:


### PR DESCRIPTION
## What

Migrate every `.github/workflows/*.yml` reusable-workflow caller from the personal repo `antst/alkemio-github-workflows` to the org repo `alkem-io/github-workflows`.

The org repo is now the **canonical home** for the shared workflows; `@v1` resolves there. This is a **pure path swap** — the workflow content is identical, and the `@v1` tag is pinned.

## Files changed

- `build-deploy-k8s-dev-hetzner.yml`
- `build-deploy-k8s-test-hetzner.yml`
- `build-deploy-k8s-sandbox-hetzner.yml`
- `build-push-ghcr-pr.yml`
- `build-release-docker-hub.yml`
- `ci-test.yml`

Each: `antst/alkemio-github-workflows/...@v1` → `alkem-io/github-workflows/...@v1`.

## Verification

- Zero `antst/alkemio` references remain in `.github/workflows/`.
- All touched files still parse as valid YAML.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline infrastructure references to use current deployment and testing workflow sources for improved maintenance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- pr-image-report:start -->
---
### 📦 PR image — test the current state of this PR

```bash
docker pull ghcr.io/alkem-io/file-service:pr-44
```

Current build: `ghcr.io/alkem-io/file-service:pr-44-c7f1da5` · `linux/amd64` + `linux/arm64` · index digest `sha256:bc1627aa22d6d64ec7a5053fd03c18623690a53f60515c37a5c134e17075fc5a`
<!-- pr-image-report:end -->
