### PR TITLE
docs: correct stale /document → /file route paths in handler comments

### DIFF
--- a/internal/adapter/inbound/http/document_handler.go
+++ b/internal/adapter/inbound/http/document_handler.go
@@ -39,7 +39,7 @@ type DocumentHandler struct {
 	IdleTimeout   time.Duration
 }
 
-// GetMeta handles GET /internal/document/{id}/meta
+// GetMeta handles GET /internal/file/{id}/meta
 func (h *DocumentHandler) GetMeta(w http.ResponseWriter, r *http.Request) {
 	docID, err := parseDocID(r)
 	if err != nil {
@@ -61,7 +61,7 @@ func (h *DocumentHandler) GetMeta(w http.ResponseWriter, r *http.Request) {
 	documentMetaResponse(doc).Render(w)
 }
 
-// GetContent handles GET /internal/document/{id}/content
+// GetContent handles GET /internal/file/{id}/content
 func (h *DocumentHandler) GetContent(w http.ResponseWriter, r *http.Request) {
 	docID, err := parseDocID(r)
 	if err != nil {
@@ -500,7 +500,7 @@ func (h *DocumentHandler) Copy(w http.ResponseWriter, r *http.Request) {
 	}.Render(w)
 }
 
-// Delete handles DELETE /internal/document/{id}
+// Delete handles DELETE /internal/file/{id}
 func (h *DocumentHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	docID, err := parseDocID(r)
 	if err != nil {

--- a/internal/adapter/inbound/http/public_handler.go
+++ b/internal/adapter/inbound/http/public_handler.go
@@ -24,7 +24,7 @@ type PublicHandler struct {
 	Logger  *zap.Logger
 }
 
-// ServeDocument handles GET /rest/storage/document/{id}
+// ServeDocument handles GET /rest/storage/file/{id} (and the /rest/storage/document/{id} back-compat alias)
 func (h *PublicHandler) ServeDocument(w http.ResponseWriter, r *http.Request) {
 	idStr := chi.URLParam(r, "id")
 	docID, err := uuid.Parse(idStr)

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -345,7 +345,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/http.errorResponse'
           description: Internal Server Error
-      summary: Delete handles DELETE /internal/document/{id}
+      summary: Delete handles DELETE /internal/file/{id}
       tags:
         - /internal
     patch:
@@ -442,7 +442,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/http.errorResponse'
           description: Internal Server Error
-      summary: GetContent handles GET /internal/document/{id}/content
+      summary: GetContent handles GET /internal/file/{id}/content
       tags:
         - /internal
     put:
@@ -535,7 +535,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/http.errorResponse'
           description: Internal Server Error
-      summary: GetMeta handles GET /internal/document/{id}/meta
+      summary: GetMeta handles GET /internal/file/{id}/meta
       tags:
         - /internal
   /live:
@@ -595,6 +595,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/http.errorResponse'
           description: Service Unavailable
-      summary: ServeDocument handles GET /rest/storage/document/{id}
+      summary: ServeDocument handles GET /rest/storage/file/{id} (and the /rest/storage/document/{id} back-compat alias)
       tags:
         - /rest/storage


### PR DESCRIPTION
Follow-up from the apispec v0.4.25 rollout. Now that the generator lifts handler doc comments into operation summaries, it surfaced that four handler comments referenced `/document/...` paths that no longer exist (routes were renamed to `/file/...`).

- `GetMeta`, `GetContent`, `Delete` — comments said `/internal/document/...`; routes are `/internal/file/...` (there is no `/internal/document` route).
- `ServeDocument` — repointed to the primary `/rest/storage/file/{id}`, noting the live `/rest/storage/document/{id}` back-compat alias.

`openapi.yaml` regenerated (apispec v0.4.25); diff is 4 summary lines. Comment-only source change — no behavior change. CodeRabbit flagged this on #45.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API documentation to reflect current routing structure and clarify endpoint paths.
  * Added documentation for backward compatibility support on file storage endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- pr-image-report:start -->
---
### 📦 PR image — test the current state of this PR

```bash
docker pull ghcr.io/alkem-io/file-service:pr-46
```

Current build: `ghcr.io/alkem-io/file-service:pr-46-0f35960` · `linux/amd64` + `linux/arm64` · index digest `sha256:a0261fd915525718fb40cd35ac0962fbf7313065fdef4691e88aff6d07e27b54`
<!-- pr-image-report:end -->
