### PR TITLE
fix(dedup): retry winner re-query to survive commit-visibility race

### DIFF
--- a/internal/domain/service/file_service.go
+++ b/internal/domain/service/file_service.go
@@ -58,6 +58,11 @@ type FileService struct {
 	Storage   port.StoragePort
 	Processor port.ImageProcessor
 	Logger    *zap.Logger
+
+	// sleep is the backoff hook for the dedup-race winner re-query. nil means
+	// time.Sleep (production); tests inject a no-op to run instantly. Optional
+	// so existing struct-literal constructions stay valid.
+	sleep func(time.Duration)
 }
 
 // ServeResult contains file content and metadata for serving.
@@ -299,9 +304,9 @@ func (s *FileService) insertDocument(ctx context.Context, input model.CreateDocu
 			return nil, ErrConflict
 		}
 		// Default path: another concurrent creator won the race on the
-		// unique(externalID, storageBucketID) index. Re-query and return
-		// the winner with Reused=true.
-		raced, findErr := s.Repo.FindByExternalIDAndBucket(ctx, stored.ExternalID, input.StorageBucketID)
+		// unique(externalID, storageBucketID) index. Re-query and return the
+		// winner with Reused=true.
+		raced, findErr := s.reQueryRaceWinner(ctx, stored.ExternalID, input.StorageBucketID)
 		if findErr == nil {
 			raced.Reused = true
 			return &raced, nil
@@ -311,6 +316,73 @@ func (s *FileService) insertDocument(ctx context.Context, input model.CreateDocu
 		return nil, fmt.Errorf("create document record: duplicate key, winner lookup failed: %w", findErr)
 	}
 	return nil, fmt.Errorf("create document record: %w", err)
+}
+
+// dedupReQueryAttempts and dedupReQueryBaseBackoff bound the winner re-query
+// after a unique-violation. The insert and the re-query use the same
+// (externalID, storageBucketID) scope and run as separate autocommit
+// statements on a pooled connection (no enclosing transaction), so the winning
+// INSERT is occasionally not yet visible to the loser's connection the instant
+// the violation fires — visibility settles a few milliseconds later. A single
+// re-query then spuriously returns ErrDocumentNotFound and the request 500s
+// ("dedup: unique violation but re-query failed … document not found").
+// Re-querying a few times with a short capped backoff turns that lost race
+// back into a successful dedup. Values are intentionally small: the contention
+// window is sub-millisecond and we must not stall the request thread.
+const (
+	dedupReQueryAttempts    = 5
+	dedupReQueryBaseBackoff = 2 * time.Millisecond
+	dedupReQueryMaxBackoff  = 20 * time.Millisecond
+)
+
+// reQueryRaceWinner re-reads the dedup winner after a unique-violation,
+// retrying with a short bounded backoff while the lookup still reports
+// ErrDocumentNotFound — the commit-visibility window. Any other lookup error
+// (or a hit) returns immediately; ErrDocumentNotFound is only returned after
+// the attempts are exhausted, so the caller can still surface a clear failure
+// if the winner genuinely never materializes.
+func (s *FileService) reQueryRaceWinner(ctx context.Context, externalID string, bucketID uuid.UUID) (model.Document, error) {
+	backoff := dedupReQueryBaseBackoff
+	var lastErr error
+	for attempt := 0; attempt < dedupReQueryAttempts; attempt++ {
+		if attempt > 0 {
+			if err := s.dedupBackoff(ctx, backoff); err != nil {
+				return model.Document{}, err
+			}
+			if backoff *= 2; backoff > dedupReQueryMaxBackoff {
+				backoff = dedupReQueryMaxBackoff
+			}
+		}
+		doc, err := s.Repo.FindByExternalIDAndBucket(ctx, externalID, bucketID)
+		if err == nil {
+			return doc, nil
+		}
+		if !errors.Is(err, model.ErrDocumentNotFound) {
+			// A real lookup failure (transport/DB) — don't mask it as a
+			// visibility lag; fail fast.
+			return model.Document{}, err
+		}
+		lastErr = err
+	}
+	return model.Document{}, lastErr
+}
+
+// dedupBackoff sleeps for d, honoring context cancellation so a client that
+// hangs up doesn't pin the request thread through the retry loop. Uses the
+// injected sleep hook when set (tests), else a ctx-aware timer.
+func (s *FileService) dedupBackoff(ctx context.Context, d time.Duration) error {
+	if s.sleep != nil {
+		s.sleep(d)
+		return ctx.Err()
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 // DeleteDocument removes a document record and its file (if not shared).

--- a/internal/domain/service/file_service_test.go
+++ b/internal/domain/service/file_service_test.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"errors"
 	"io"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"go.uber.org/zap"
@@ -416,6 +418,185 @@ func TestCreateDocument_Dedup_CreateRace_ReturnsWinnerAsReused(t *testing.T) {
 	}
 }
 
+// Commit-visibility race: two requests upload identical content concurrently.
+// The loser's Create hits the unique violation (ErrDuplicateKey), but the
+// winner's INSERT is not yet visible on the loser's pooled connection, so the
+// first winner re-query returns ErrDocumentNotFound. The dedup recovery must
+// retry the re-query (bounded backoff) until the winner becomes visible and
+// return it as Reused — never surface a 500. Regression test for the
+// "dedup: unique violation but re-query failed … document not found" 500s
+// observed in the unified-collab empty-memo e2e (two collab clients snapshot
+// identical bytes → identical hash → same-bucket collision).
+func TestCreateDocument_Dedup_CreateRace_WinnerNotYetVisible_RetriesThenReturnsWinner(t *testing.T) {
+	winnerID := uuid.New()
+	winnerAuth := uuid.New()
+	bucket := uuid.New()
+
+	// find call #1 (pre-Create dedup check): no row → fall through to Create.
+	// find calls #2..#N (post-violation re-query): winner invisible for the
+	// first few attempts (visibility lag across pooled connections), then
+	// becomes visible. The fix must keep retrying past the not-found window.
+	const invisibleReQueries = 2 // re-query attempts that still see "not found"
+	callCount := 0
+	repo := &mockRepoRace{
+		find: func() (model.Document, error) {
+			callCount++
+			if callCount == 1 {
+				return model.Document{}, model.ErrDocumentNotFound
+			}
+			if callCount <= 1+invisibleReQueries {
+				// Winner committed but not yet visible to this connection.
+				return model.Document{}, model.ErrDocumentNotFound
+			}
+			return model.Document{
+				ID:              winnerID,
+				ExternalID:      "sha3-of-content",
+				StorageBucketID: bucket,
+				AuthorizationID: winnerAuth,
+			}, nil
+		},
+		createErr: model.ErrDuplicateKey,
+	}
+	svc := &FileService{Logger: nopLogger, Repo: repo, Storage: &mockStorage{}, Processor: &mockProcessor{}}
+	svc.sleep = func(time.Duration) {} // no real backoff sleeps in tests
+
+	input := model.CreateDocumentInput{
+		DisplayName:     "empty-memo.txt",
+		StorageBucketID: bucket,
+		AuthorizationID: uuid.New(),
+	}
+	doc, err := svc.CreateDocument(context.Background(), input, []byte("content"), "", nil, 0)
+	if err != nil {
+		t.Fatalf("dedup must recover from the visibility window, got 500-class error: %v", err)
+	}
+	if !doc.Reused {
+		t.Error("expected Reused=true after losing the create race")
+	}
+	if doc.ID != winnerID {
+		t.Errorf("ID = %v, want winner %v", doc.ID, winnerID)
+	}
+	if doc.AuthorizationID != winnerAuth {
+		t.Errorf("AuthorizationID = %v, want winner %v", doc.AuthorizationID, winnerAuth)
+	}
+	// Pre-create check (1) + the invisible re-queries + the successful one.
+	wantMinFinds := 1 + invisibleReQueries + 1
+	if repo.findCalls < wantMinFinds {
+		t.Errorf("expected the winner re-query to be retried past the not-found window: findCalls = %d, want >= %d", repo.findCalls, wantMinFinds)
+	}
+}
+
+// Terminal case: Create hit ErrDuplicateKey but the winner is never visible
+// (genuinely missing row — e.g. winner rolled back, or visibility never
+// settles). The recovery must exhaust its bounded retries and then surface a
+// wrapped error rather than spin forever. The pre-create check is one find;
+// the re-query is then attempted multiple times.
+func TestCreateDocument_Dedup_CreateRace_WinnerNeverVisible_ExhaustsRetriesAndErrors(t *testing.T) {
+	bucket := uuid.New()
+	callCount := 0
+	repo := &mockRepoRace{
+		find: func() (model.Document, error) {
+			callCount++
+			// Always "not found": first call is the pre-create check, the rest
+			// are the re-query that never resolves.
+			return model.Document{}, model.ErrDocumentNotFound
+		},
+		createErr: model.ErrDuplicateKey,
+	}
+	svc := &FileService{Logger: nopLogger, Repo: repo, Storage: &mockStorage{}, Processor: &mockProcessor{}}
+	svc.sleep = func(time.Duration) {}
+
+	input := model.CreateDocumentInput{
+		DisplayName:     "test.txt",
+		StorageBucketID: bucket,
+		AuthorizationID: uuid.New(),
+	}
+	_, err := svc.CreateDocument(context.Background(), input, []byte("content"), "", nil, 0)
+	if err == nil {
+		t.Fatal("expected an error when the race winner never becomes visible")
+	}
+	// Must have retried the re-query (more than the single pre-create find).
+	if repo.findCalls < 3 {
+		t.Errorf("expected the re-query to be retried before giving up: findCalls = %d, want >= 3", repo.findCalls)
+	}
+}
+
+// A real lookup failure (transport/DB) during the post-violation re-query
+// must NOT be retried as if it were a visibility lag: it fails fast and the
+// error is surfaced. Guards against the bounded retry masking genuine DB
+// outages.
+func TestCreateDocument_Dedup_CreateRace_ReQueryTransportError_FailsFast(t *testing.T) {
+	bucket := uuid.New()
+	transportErr := errors.New("connection reset by peer")
+	callCount := 0
+	repo := &mockRepoRace{
+		find: func() (model.Document, error) {
+			callCount++
+			if callCount == 1 {
+				return model.Document{}, model.ErrDocumentNotFound // pre-create check
+			}
+			return model.Document{}, transportErr // re-query: real DB failure
+		},
+		createErr: model.ErrDuplicateKey,
+	}
+	svc := &FileService{Logger: nopLogger, Repo: repo, Storage: &mockStorage{}, Processor: &mockProcessor{}}
+	svc.sleep = func(time.Duration) {}
+
+	input := model.CreateDocumentInput{
+		DisplayName:     "test.txt",
+		StorageBucketID: bucket,
+		AuthorizationID: uuid.New(),
+	}
+	_, err := svc.CreateDocument(context.Background(), input, []byte("content"), "", nil, 0)
+	if err == nil {
+		t.Fatal("expected the transport error to surface")
+	}
+	if !errors.Is(err, transportErr) {
+		t.Errorf("expected wrapped transport error, got %v", err)
+	}
+	// Pre-create check (1) + exactly one re-query that fails fast (2). No retry.
+	if repo.findCalls != 2 {
+		t.Errorf("a real lookup failure must not be retried: findCalls = %d, want 2", repo.findCalls)
+	}
+}
+
+// A context cancelled during the dedup backoff window aborts the re-query loop
+// promptly rather than pinning the request thread for the full retry budget.
+// Exercises the production ctx-aware timer path (no injected sleep hook).
+func TestCreateDocument_Dedup_CreateRace_ContextCancelledDuringBackoff(t *testing.T) {
+	bucket := uuid.New()
+	callCount := 0
+	repo := &mockRepoRace{
+		find: func() (model.Document, error) {
+			callCount++
+			// Always not-found so the loop enters the backoff between attempts.
+			return model.Document{}, model.ErrDocumentNotFound
+		},
+		createErr: model.ErrDuplicateKey,
+	}
+	// No svc.sleep injected → real ctx-aware timer is used.
+	svc := &FileService{Logger: nopLogger, Repo: repo, Storage: &mockStorage{}, Processor: &mockProcessor{}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel almost immediately so the first inter-attempt backoff observes it.
+	go func() {
+		time.Sleep(1 * time.Millisecond)
+		cancel()
+	}()
+
+	input := model.CreateDocumentInput{
+		DisplayName:     "test.txt",
+		StorageBucketID: bucket,
+		AuthorizationID: uuid.New(),
+	}
+	_, err := svc.CreateDocument(ctx, input, []byte("content"), "", nil, 0)
+	if err == nil {
+		t.Fatal("expected an error after context cancellation")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled to propagate, got %v", err)
+	}
+}
+
 // SkipDedup: true → fresh row inserted even when an existing row matches.
 // Lookup must NOT be called; existing row must NOT be returned/mutated.
 func TestCreateDocument_SkipDedup_InsertsFreshRowWhenContentExists(t *testing.T) {
@@ -558,6 +739,7 @@ func TestCreateDocument_SkipDedup_DuplicateKey_ReturnsConflict(t *testing.T) {
 type mockRepoRace struct {
 	find      func() (model.Document, error)
 	createErr error
+	findCalls int
 }
 
 var _ port.DocumentRepo = (*mockRepoRace)(nil)
@@ -566,6 +748,7 @@ func (m *mockRepoRace) GetByID(_ context.Context, _ uuid.UUID) (model.Document, 
 	return model.Document{}, nil
 }
 func (m *mockRepoRace) FindByExternalIDAndBucket(_ context.Context, _ string, _ uuid.UUID) (model.Document, error) {
+	m.findCalls++
 	return m.find()
 }
 func (m *mockRepoRace) Create(_ context.Context, _ model.Document, _ model.ContentMetadata) (uuid.UUID, error) {
@@ -1784,4 +1967,170 @@ func (m *mockProcessor) TranscodeStream(r io.Reader, w io.Writer, mimeType strin
 
 func (m *dedupMockStorage) OpenStage(_ context.Context) (port.StageWriter, error) {
 	return nil, errors.New("dedupMockStorage: OpenStage not used in these tests")
+}
+
+// concurrentDedupRepo is a thread-safe, stateful DocumentRepo that faithfully
+// simulates the production database for the dedup race: Create enforces a
+// unique(externalID, storageBucketID) index (first writer wins, the rest get
+// ErrDuplicateKey), and FindByExternalIDAndBucket reflects committed rows —
+// but only after a configurable visibility delay, modelling the brief window
+// where a winning INSERT on one pooled connection is not yet visible to a
+// loser re-querying on another. Used by the end-to-end concurrency regression
+// test. -race clean.
+type concurrentDedupRepo struct {
+	mu sync.Mutex
+	// rows keyed by (externalID, bucket) — the unique index.
+	rows map[string]model.Document
+	// committedAt records when each key became visible to re-queries.
+	committedAt map[string]time.Time
+	// visibilityLag delays when a freshly-inserted row is observable by
+	// FindByExternalIDAndBucket (the commit-visibility window).
+	visibilityLag time.Duration
+	now           func() time.Time
+}
+
+var _ port.DocumentRepo = (*concurrentDedupRepo)(nil)
+
+func newConcurrentDedupRepo(lag time.Duration) *concurrentDedupRepo {
+	return &concurrentDedupRepo{
+		rows:          map[string]model.Document{},
+		committedAt:   map[string]time.Time{},
+		visibilityLag: lag,
+		now:           time.Now,
+	}
+}
+
+func dedupKey(externalID string, bucket uuid.UUID) string {
+	return externalID + "|" + bucket.String()
+}
+
+func (m *concurrentDedupRepo) Create(_ context.Context, doc model.Document, _ model.ContentMetadata) (uuid.UUID, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	k := dedupKey(doc.ExternalID, doc.StorageBucketID)
+	if _, exists := m.rows[k]; exists {
+		// Unique index violation — another writer already holds this content
+		// in this bucket.
+		return uuid.Nil, model.ErrDuplicateKey
+	}
+	m.rows[k] = doc
+	m.committedAt[k] = m.now().Add(m.visibilityLag)
+	return doc.ID, nil
+}
+
+func (m *concurrentDedupRepo) FindByExternalIDAndBucket(_ context.Context, externalID string, bucket uuid.UUID) (model.Document, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	k := dedupKey(externalID, bucket)
+	doc, exists := m.rows[k]
+	if !exists {
+		return model.Document{}, model.ErrDocumentNotFound
+	}
+	if m.now().Before(m.committedAt[k]) {
+		// Row exists but is not yet visible on this connection.
+		return model.Document{}, model.ErrDocumentNotFound
+	}
+	return doc, nil
+}
+
+func (m *concurrentDedupRepo) GetByID(_ context.Context, _ uuid.UUID) (model.Document, error) {
+	return model.Document{}, model.ErrDocumentNotFound
+}
+func (m *concurrentDedupRepo) UpdateFile(_ context.Context, _ uuid.UUID, _, _ string, _ int, _ model.ContentMetadata) error {
+	return nil
+}
+func (m *concurrentDedupRepo) UpdateMetadata(_ context.Context, _ uuid.UUID, _ uuid.UUID, _ bool, _ string, _ int) error {
+	return nil
+}
+func (m *concurrentDedupRepo) BackfillContentMetadata(_ context.Context, _ uuid.UUID, _ string, _ model.ContentMetadata) error {
+	return nil
+}
+func (m *concurrentDedupRepo) Delete(_ context.Context, _ uuid.UUID) (model.DeletedDocument, error) {
+	return model.DeletedDocument{}, nil
+}
+func (m *concurrentDedupRepo) CountByExternalID(_ context.Context, _ string) (int, error) {
+	return 0, nil
+}
+func (m *concurrentDedupRepo) ListByMimeTypes(_ context.Context, _ []string) ([]model.Document, error) {
+	return nil, nil
+}
+func (m *concurrentDedupRepo) UpdateMimeType(_ context.Context, _ uuid.UUID, _, _ string) (bool, error) {
+	return true, nil
+}
+
+// TestCreateDocument_ConcurrentIdenticalContent_BothDedupNo500 is the
+// end-to-end regression test for the dedup upsert race surfaced by the
+// unified-collab empty-memo e2e: two requests upload byte-identical content
+// (same content-hash externalID) into the same bucket at the same time. With a
+// commit-visibility lag in play, exactly one INSERT wins; the loser must
+// recover the winner via the bounded re-query and return it as a dedup hit.
+// Both requests must succeed, return the SAME document id, and produce ZERO
+// 500-class errors. Run under -race.
+func TestCreateDocument_ConcurrentIdenticalContent_BothDedupNo500(t *testing.T) {
+	bucket := uuid.New()
+	// Visibility lag longer than the first backoff so the loser's first
+	// re-query reliably misses and must retry — the exact failure mode.
+	repo := newConcurrentDedupRepo(5 * time.Millisecond)
+
+	content := []byte("") // empty memo snapshot: identical bytes, identical hash
+	const goroutines = 8
+
+	type result struct {
+		doc *model.Document
+		err error
+	}
+	results := make([]result, goroutines)
+
+	var start sync.WaitGroup
+	start.Add(1)
+	var done sync.WaitGroup
+	done.Add(goroutines)
+
+	for i := 0; i < goroutines; i++ {
+		go func(idx int) {
+			defer done.Done()
+			// Each goroutine gets its own storage/processor (one writer per
+			// instance) so only the shared repo exercises concurrency.
+			svc := &FileService{
+				Logger:    nopLogger,
+				Repo:      repo,
+				Storage:   &mockStorage{},
+				Processor: &mockProcessor{},
+			}
+			input := model.CreateDocumentInput{
+				DisplayName:     "empty-memo.txt",
+				StorageBucketID: bucket,
+				AuthorizationID: uuid.New(),
+			}
+			start.Wait() // release all goroutines together
+			doc, err := svc.CreateDocument(context.Background(), input, content, "", nil, 0)
+			results[idx] = result{doc: doc, err: err}
+		}(i)
+	}
+
+	start.Done()
+	done.Wait()
+
+	var winnerID uuid.UUID
+	reusedCount := 0
+	for i, r := range results {
+		if r.err != nil {
+			t.Fatalf("goroutine %d: identical-content upload must dedup, got error (500): %v", i, r.err)
+		}
+		if r.doc == nil {
+			t.Fatalf("goroutine %d: nil document with no error", i)
+		}
+		if winnerID == uuid.Nil {
+			winnerID = r.doc.ID
+		} else if r.doc.ID != winnerID {
+			t.Errorf("goroutine %d: doc ID = %v, want the single winner %v (dedup must converge on one row)", i, r.doc.ID, winnerID)
+		}
+		if r.doc.Reused {
+			reusedCount++
+		}
+	}
+	// Exactly one inserter wins; every other request is a dedup hit (Reused).
+	if reusedCount != goroutines-1 {
+		t.Errorf("expected %d dedup hits (Reused=true), got %d", goroutines-1, reusedCount)
+	}
 }


### PR DESCRIPTION
## Problem

When two requests upload **byte-identical content** (same content-hash `externalID`) into the **same bucket concurrently**, the second `Create` hits the `unique(externalID, storageBucketID)` index and returns `ErrDuplicateKey`. The dedup recovery in `insertDocument` then re-queries the winning row via `FindByExternalIDAndBucket` and returns it as a dedup hit (`Reused=true`).

The previous recovery re-queried **once**. The insert and the re-query run as **separate autocommit statements on a pooled connection** (no enclosing transaction), so the winning `INSERT` is occasionally **not yet visible** to the loser's connection at the instant the violation fires. The single re-query then returned `ErrDocumentNotFound` and the request **500'd**:

```
dedup: unique violation but re-query failed … document not found
create document record: duplicate key, winner lookup failed
```

This surfaced in the unified-collab empty-memo e2e: two collab clients snapshot identical empty bytes → identical hash → same-bucket collision.

## Root cause

A **commit-visibility race**, not a bucket-scope mismatch. The `CreateDocument` INSERT and the `FindDocumentByExternalIDAndBucket` re-query filter by the **identical** scope (`"externalID" = $1 AND "storageBucketId" = $2`), so the loser is looking in the right bucket — the winning row just isn't visible yet on its pooled connection (the window the `FindDocumentByExternalIDAndBucket` doc comment already anticipates: "two racing inserts").

## Fix

Re-query the winner with a **short bounded backoff** (5 attempts, 2 ms base → 20 ms cap) while the lookup reports `ErrDocumentNotFound`, so the losing upload reliably converges on the winner — a successful dedup, never a 500.

- A **real** lookup failure (transport/DB) is surfaced immediately, never retried as a visibility lag.
- The backoff **honors context cancellation**, so a hung-up client cannot pin the request thread through the retry budget.
- `SkipDedup` semantics, error mapping, and the audit-field behavior are unchanged. The permissive `externalID` validator (legacy IPFS CIDs, PR #13) is **untouched** — this race is in the upsert path.

Considered but not chosen: `INSERT … ON CONFLICT … RETURNING`. The `unique(externalID, storageBucketID)` constraint exists only in the production schema, not in this repo's `db/schema/document.sql`, so a portable single-statement upsert can't rely on it here. The bounded re-query is the surgical, schema-agnostic fix that lives entirely in the domain service.

## Tests (TDD — fail-before / pass-after, `-race` clean)

- **Visibility-window race:** loser's first re-queries miss, the bounded retry returns the winner as `Reused`.
- **Exhaustion:** winner never becomes visible → retries exhaust, then a clear wrapped error (no infinite spin).
- **Transport error on re-query:** fails fast, no retry.
- **Context cancelled during backoff:** propagates `context.Canceled`.
- **End-to-end concurrency:** 8 goroutines upload identical empty-memo bytes through `CreateDocument`; all succeed, converge on one row, **zero 500s** (faithful stateful repo mock enforcing the unique index + a commit-visibility lag).

All five fail against the pre-fix single re-query and pass after.

## Gates

- `make test` — green, `-race` clean, full suite.
- `make lint` — 0 issues.
- New `reQueryRaceWinner` / `dedupBackoff` at 100% line coverage; the only uncovered touched-package line is the pre-existing unreachable `uuid.NewV7()` error path.
- `make test-vips` not required (imaging untouched).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved document deduplication reliability when concurrent uploads of identical content occur.
  * Enhanced duplicate detection recovery to handle database visibility lag with automatic retry logic.

* **Tests**
  * Added comprehensive test coverage for concurrent deduplication edge cases and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- pr-image-report:start -->
---
### 📦 PR image — test the current state of this PR

```bash
docker pull ghcr.io/alkem-io/file-service:pr-49
```

Current build: `ghcr.io/alkem-io/file-service:pr-49-5b6608b` · `linux/amd64` + `linux/arm64` · index digest `sha256:04b12b1e37b48f0706311b2f5878fcda108cf6595f90de0e8588c32147dbdf0c`
<!-- pr-image-report:end -->
