### PR TITLE
fix(create): persist omitted authorizationId as SQL NULL

### DIFF
--- a/internal/adapter/inbound/http/document_handler.go
+++ b/internal/adapter/inbound/http/document_handler.go
@@ -202,6 +202,19 @@ func parseOptionalUUID(value, field string) (*uuid.UUID, error) {
 	return &parsed, nil
 }
 
+// parseCreateAuthorizationID accepts omission as uuid.Nil (the domain's
+// explicit SQL-NULL signal) but rejects an explicitly supplied all-zero UUID.
+func parseCreateAuthorizationID(value string) (uuid.UUID, error) {
+	if value == "" {
+		return uuid.Nil, nil
+	}
+	parsed, err := uuid.Parse(value)
+	if err != nil || parsed == uuid.Nil {
+		return uuid.Nil, fmt.Errorf("invalid authorizationId")
+	}
+	return parsed, nil
+}
+
 // parseOptionalBool parses an optional boolean form field: empty means
 // false. The error names the field so it can serve directly as a 400 body.
 func parseOptionalBool(value, field string) (bool, error) {
@@ -227,9 +240,9 @@ func buildCreateInput(fields createFields) (input model.CreateDocumentInput, all
 		return input, nil, 0, fmt.Errorf("invalid storageBucketId")
 	}
 
-	authorizationID, err := uuid.Parse(fields.authorizationID)
+	authorizationID, err := parseCreateAuthorizationID(fields.authorizationID)
 	if err != nil {
-		return input, nil, 0, fmt.Errorf("invalid authorizationId")
+		return input, nil, 0, err
 	}
 
 	tagsetID, err := parseOptionalUUID(fields.tagsetID, "tagsetId")
@@ -416,8 +429,8 @@ func (h *DocumentHandler) readMetadataField(w http.ResponseWriter, fields *creat
 
 // writeCompleteUploadError maps a CompleteUpload failure to its HTTP
 // response and outcome counter (spec 020 FR-008): bucket-policy rejections
-// (size, MIME) are 413/415, a SkipDedup content collision is 409, anything
-// else is a logged 500.
+// (size, MIME) are 413/415, uniqueness conflicts are 409, anything else is
+// a logged 500.
 func (h *DocumentHandler) writeCompleteUploadError(w http.ResponseWriter, err error) {
 	switch {
 	case errors.Is(err, service.ErrPayloadTooLarge):
@@ -427,7 +440,7 @@ func (h *DocumentHandler) writeCompleteUploadError(w http.ResponseWriter, err er
 		IngestOutcomes.Add("rejected_bucket_policy", 1)
 		writeJSONError(w, http.StatusUnsupportedMediaType, "unsupported media type")
 	case errors.Is(err, service.ErrConflict):
-		writeJSONError(w, http.StatusConflict, "skipDedup requested but a row with this content already exists in the bucket")
+		writeJSONError(w, http.StatusConflict, "document conflicts with an existing row")
 	default:
 		IngestOutcomes.Add("failed_mid_stream", 1)
 		h.Logger.Error("failed to create document", zap.Error(err))
@@ -529,12 +542,12 @@ func (h *DocumentHandler) Copy(w http.ResponseWriter, r *http.Request) {
 	doc, err := h.Service.CopyDocument(r.Context(), sourceID, input)
 	if err != nil {
 		switch {
+		case errors.Is(err, service.ErrInvalidAuthorizationID):
+			writeJSONError(w, http.StatusBadRequest, "invalid authorizationId")
 		case errors.Is(err, model.ErrDocumentNotFound):
 			writeJSONError(w, http.StatusNotFound, "source document not found")
 		case errors.Is(err, service.ErrConflict):
-			// Reachable only when SkipDedup=true and the destination bucket
-			// already has a row with this content under the unique index.
-			writeJSONError(w, http.StatusConflict, "skipDedup requested but a row with this content already exists in the destination bucket")
+			writeJSONError(w, http.StatusConflict, "copy conflicts with an existing row")
 		default:
 			h.Logger.Error("failed to copy document", zap.Error(err))
 			writeJSONError(w, http.StatusInternalServerError, "internal error")

--- a/internal/adapter/inbound/http/document_handler_test.go
+++ b/internal/adapter/inbound/http/document_handler_test.go
@@ -261,6 +261,57 @@ func TestDocumentHandler_Create_Success(t *testing.T) {
 	}
 }
 
+func TestDocumentHandler_Create_OmittedAuthorization_CreatesNullAuthRow(t *testing.T) {
+	h, repo, _ := newDocHandler()
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	part, _ := writer.CreateFormFile("file", "snapshot.ybin")
+	_, _ = part.Write([]byte("snapshot"))
+	_ = writer.WriteField("displayName", "snapshot.ybin")
+	_ = writer.WriteField("storageBucketId", uuid.New().String())
+	// authorizationId deliberately omitted.
+	_ = writer.Close()
+
+	r := chi.NewRouter()
+	r.Post("/internal/file", h.Create)
+	req := httptest.NewRequest(http.MethodPost, "/internal/file", &body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201, body: %s", rr.Code, rr.Body.String())
+	}
+	if repo.lastCreateDoc.AuthorizationID != uuid.Nil {
+		t.Fatalf("repo authorizationId = %s, want uuid.Nil (SQL NULL)", repo.lastCreateDoc.AuthorizationID)
+	}
+}
+
+func TestDocumentHandler_Create_ExplicitNilAuthorization_400(t *testing.T) {
+	h, _, _ := newDocHandler()
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	part, _ := writer.CreateFormFile("file", "snapshot.ybin")
+	_, _ = part.Write([]byte("snapshot"))
+	_ = writer.WriteField("displayName", "snapshot.ybin")
+	_ = writer.WriteField("storageBucketId", uuid.New().String())
+	_ = writer.WriteField("authorizationId", uuid.Nil.String())
+	_ = writer.Close()
+
+	r := chi.NewRouter()
+	r.Post("/internal/file", h.Create)
+	req := httptest.NewRequest(http.MethodPost, "/internal/file", &body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400, body: %s", rr.Code, rr.Body.String())
+	}
+}
+
 func TestDocumentHandler_Create_Success_NotReused(t *testing.T) {
 	h, _, _ := newDocHandler()
 
@@ -403,6 +454,33 @@ func TestDocumentHandler_Create_SkipDedup_Conflict_Returns409(t *testing.T) {
 	r := chi.NewRouter()
 	r.Post("/internal/file", h.Create)
 
+	req := httptest.NewRequest(http.MethodPost, "/internal/file", &body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409, body: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestDocumentHandler_Create_AuthorizationCollision_Returns409(t *testing.T) {
+	h, repo, _ := newDocHandler()
+	// No (externalID, bucket) winner exists in the default mock, so this
+	// unique violation represents authorizationId/tagsetId reuse.
+	repo.createErr = model.ErrDuplicateKey
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	part, _ := writer.CreateFormFile("file", "snapshot.ybin")
+	_, _ = part.Write([]byte("snapshot"))
+	_ = writer.WriteField("displayName", "snapshot.ybin")
+	_ = writer.WriteField("storageBucketId", uuid.New().String())
+	_ = writer.WriteField("authorizationId", uuid.New().String())
+	_ = writer.Close()
+
+	r := chi.NewRouter()
+	r.Post("/internal/file", h.Create)
 	req := httptest.NewRequest(http.MethodPost, "/internal/file", &body)
 	req.Header.Set("Content-Type", writer.FormDataContentType())
 	rr := httptest.NewRecorder()
@@ -575,6 +653,26 @@ func TestDocumentHandler_Copy_InvalidSourceID_400(t *testing.T) {
 
 	if rr.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400", rr.Code)
+	}
+}
+
+func TestDocumentHandler_Copy_NilAuthorizationID_400(t *testing.T) {
+	h, _, _ := newDocHandler()
+
+	body, _ := json.Marshal(CopyDocumentRequest{
+		SourceID:            uuid.New().String(),
+		DestinationBucketID: uuid.New().String(),
+		AuthorizationID:     uuid.Nil.String(),
+	})
+	r := chi.NewRouter()
+	r.Post("/internal/file/copy", h.Copy)
+	req := httptest.NewRequest(http.MethodPost, "/internal/file/copy", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400, body: %s", rr.Code, rr.Body.String())
 	}
 }
 

--- a/internal/adapter/inbound/http/public_handler_test.go
+++ b/internal/adapter/inbound/http/public_handler_test.go
@@ -39,6 +39,7 @@ type mockDocRepo struct {
 	lastUpdateVersion     int
 
 	// Captured args from Create / UpdateFile content_metadata params (US1+).
+	lastCreateDoc                 model.Document
 	lastCreateContentMetadata     model.ContentMetadata
 	lastUpdateFileContentMetadata model.ContentMetadata
 
@@ -65,6 +66,7 @@ func (m *mockDocRepo) FindByExternalIDAndBucket(_ context.Context, _ string, _ u
 	return model.Document{}, model.ErrDocumentNotFound
 }
 func (m *mockDocRepo) Create(_ context.Context, doc model.Document, contentMetadata model.ContentMetadata) (uuid.UUID, error) {
+	m.lastCreateDoc = doc
 	m.lastCreateContentMetadata = contentMetadata
 	return doc.ID, m.createErr
 }

--- a/internal/adapter/outbound/alkemiodb/adapter.go
+++ b/internal/adapter/outbound/alkemiodb/adapter.go
@@ -88,9 +88,9 @@ func (a *Adapter) FindByExternalIDAndBucket(ctx context.Context, externalID stri
 
 // Create inserts a new document row, serializing contentMetadata into the
 // JSONB content_metadata column (see marshalContentMetadata for the shape
-// rules). A unique violation — another row already holds this content in the
-// bucket — surfaces as model.ErrDuplicateKey so the service can fall back to
-// its dedup path.
+// rules). Any unique violation surfaces as model.ErrDuplicateKey; the service
+// probes (externalID, bucket) once to distinguish a content winner from an
+// authorizationId/tagsetId conflict.
 func (a *Adapter) Create(ctx context.Context, doc model.Document, contentMetadata model.ContentMetadata) (uuid.UUID, error) {
 	raw, err := marshalContentMetadata(contentMetadata)
 	if err != nil {
@@ -119,16 +119,18 @@ func createDocumentParams(doc model.Document, raw []byte) queries.CreateDocument
 		CreatedBy:         uuidToPgxNullable(doc.CreatedBy),
 		TemporaryLocation: doc.TemporaryLocation,
 		StorageBucketId:   uuidToPgx(doc.StorageBucketID),
-		AuthorizationId:   uuidToPgx(doc.AuthorizationID),
-		TagsetId:          uuidToPgxNullable(doc.TagsetID),
-		CreatedDate:       timeToPgx(doc.CreatedDate),
-		UpdatedDate:       timeToPgx(doc.UpdatedDate),
-		ContentMetadata:   raw,
+		// uuid.Nil means the create caller intentionally omitted authorization.
+		// Persist SQL NULL: the FK cannot reference the all-zero UUID, while the
+		// UNIQUE column permits multiple NULL rows.
+		AuthorizationId: uuidToPgxNullableNil(doc.AuthorizationID),
+		TagsetId:        uuidToPgxNullable(doc.TagsetID),
+		CreatedDate:     timeToPgx(doc.CreatedDate),
+		UpdatedDate:     timeToPgx(doc.UpdatedDate),
+		ContentMetadata: raw,
 	}
 }
 
-// isUniqueViolation reports whether err is a Postgres unique-constraint violation — the
-// signal that another row already holds this content in the bucket (the dedup race).
+// isUniqueViolation reports whether err is any Postgres unique-constraint violation.
 func isUniqueViolation(err error) bool {
 	var pgErr *pgconn.PgError
 	return errors.As(err, &pgErr) && pgErr.Code == pgerrcode.UniqueViolation

--- a/internal/adapter/outbound/alkemiodb/adapter_mock_test.go
+++ b/internal/adapter/outbound/alkemiodb/adapter_mock_test.go
@@ -141,6 +141,19 @@ func TestMock_Create_Success(t *testing.T) {
 	}
 }
 
+func TestCreateDocumentParams_OmittedAuthorizationIsNull(t *testing.T) {
+	params := createDocumentParams(model.Document{AuthorizationID: uuid.Nil}, []byte(`{}`))
+	if params.AuthorizationId.Valid {
+		t.Fatalf("omitted authorization mapping = %+v, want SQL NULL", params.AuthorizationId)
+	}
+
+	authID := uuid.New()
+	params = createDocumentParams(model.Document{AuthorizationID: authID}, []byte(`{}`))
+	if !params.AuthorizationId.Valid || params.AuthorizationId.Bytes != authID {
+		t.Fatalf("real authorization mapping = %+v, want valid %s", params.AuthorizationId, authID)
+	}
+}
+
 func TestMock_UpdateFile_Success(t *testing.T) {
 	mock, err := pgxmock.NewPool()
 	if err != nil {

--- a/internal/adapter/outbound/alkemiodb/convert.go
+++ b/internal/adapter/outbound/alkemiodb/convert.go
@@ -50,6 +50,16 @@ func uuidToPgxNullable(id *uuid.UUID) pgtype.UUID {
 	return pgtype.UUID{Bytes: *id, Valid: true}
 }
 
+// uuidToPgxNullableNil maps uuid.Nil to SQL NULL and every real UUID to a
+// valid pgx UUID. Create and CreateWithOutbox both call createDocumentParams,
+// so this is the single nullable-authorization mapping for both write paths.
+func uuidToPgxNullableNil(id uuid.UUID) pgtype.UUID {
+	if id == uuid.Nil {
+		return pgtype.UUID{Valid: false}
+	}
+	return pgtype.UUID{Bytes: id, Valid: true}
+}
+
 func pgxToUUID(id pgtype.UUID) uuid.UUID {
 	if !id.Valid {
 		return uuid.Nil

--- a/internal/adapter/outbound/alkemiodb/convert_test.go
+++ b/internal/adapter/outbound/alkemiodb/convert_test.go
@@ -35,6 +35,21 @@ func TestUuidToPgxNullable_NonNil(t *testing.T) {
 	}
 }
 
+func TestUuidToPgxNullableNil_NilUUID(t *testing.T) {
+	pgxID := uuidToPgxNullableNil(uuid.Nil)
+	if pgxID.Valid {
+		t.Error("uuid.Nil must map to SQL NULL")
+	}
+}
+
+func TestUuidToPgxNullableNil_RealUUID(t *testing.T) {
+	id := uuid.New()
+	pgxID := uuidToPgxNullableNil(id)
+	if !pgxID.Valid || pgxID.Bytes != id {
+		t.Fatalf("real UUID mapping = %+v, want valid %s", pgxID, id)
+	}
+}
+
 func TestPgxToUUID_Valid(t *testing.T) {
 	id := uuid.New()
 	pgxID := pgtype.UUID{Bytes: id, Valid: true}

--- a/internal/adapter/outbound/alkemiodb/outbox.go
+++ b/internal/adapter/outbound/alkemiodb/outbox.go
@@ -16,8 +16,8 @@ import (
 // committed non-temporary file row carries its backup hint). After commit it emits a best-effort
 // NOTIFY so the backup worker wakes immediately — the durable table + the worker's poll floor
 // cover a lost NOTIFY. A unique violation on the document → model.ErrDuplicateKey with NO outbox
-// row written (a dedup hit means the content already exists and was already captured); the
-// service's dedup path re-queries the winner exactly as on the non-outbox path.
+// row written; the service performs the same one-shot content-winner/conflict classification as
+// on the non-outbox path.
 func (a *Adapter) CreateWithOutbox(ctx context.Context, doc model.Document, contentMetadata model.ContentMetadata, priority int16) (uuid.UUID, error) {
 	raw, err := marshalContentMetadata(contentMetadata)
 	if err != nil {

--- a/internal/adapter/outbound/alkemiodb/outbox_mock_test.go
+++ b/internal/adapter/outbound/alkemiodb/outbox_mock_test.go
@@ -64,6 +64,34 @@ func TestMock_CreateWithOutbox_Commits(t *testing.T) {
 	}
 }
 
+func TestMock_CreateWithOutbox_OmittedAuthorizationIsNull(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mock.Close()
+	docID := uuid.New()
+	doc := sampleDoc(docID)
+	doc.AuthorizationID = uuid.Nil
+
+	insertArgs := anyArgs(13)
+	insertArgs[8] = pgtype.UUID{Valid: false} // authorizationId
+	mock.ExpectBegin()
+	mock.ExpectQuery("INSERT INTO file").WithArgs(insertArgs...).
+		WillReturnRows(mock.NewRows([]string{"id"}).AddRow(pgtype.UUID{Bytes: docID, Valid: true}))
+	mock.ExpectExec("INSERT INTO file_backup_outbox").WithArgs(anyArgs(6)...).
+		WillReturnResult(pgxmock.NewResult("INSERT", 1))
+	mock.ExpectCommit()
+	mock.ExpectExec("NOTIFY file_backup_outbox").WillReturnResult(pgxmock.NewResult("NOTIFY", 0))
+
+	if _, err := New(mock).CreateWithOutbox(context.Background(), doc, model.ContentMetadata{}, 0); err != nil {
+		t.Fatalf("CreateWithOutbox: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+}
+
 // TestMock_CreateWithOutbox_DedupRollsBack: a unique violation on the document rolls the
 // transaction back (NO outbox row, NO NOTIFY) and surfaces model.ErrDuplicateKey so the
 // service's dedup path re-queries the winner.

--- a/internal/domain/model/document.go
+++ b/internal/domain/model/document.go
@@ -78,8 +78,11 @@ type CreateDocumentInput struct {
 	CreatedBy         *uuid.UUID
 	TemporaryLocation bool
 	StorageBucketID   uuid.UUID
-	AuthorizationID   uuid.UUID
-	TagsetID          *uuid.UUID
+	// AuthorizationID is optional for internal create callers. uuid.Nil
+	// persists as SQL NULL; a real UUID references an authorization policy.
+	// CopyDocumentInput intentionally remains required.
+	AuthorizationID uuid.UUID
+	TagsetID        *uuid.UUID
 
 	// SkipDedup, when true, bypasses the per-bucket content-hash dedup
 	// lookup and forces a fresh row insert even if an existing row in the

--- a/internal/domain/model/errors.go
+++ b/internal/domain/model/errors.go
@@ -5,7 +5,7 @@ import "errors"
 // ErrDocumentNotFound is returned when a document cannot be found in the repository.
 var ErrDocumentNotFound = errors.New("document not found")
 
-// ErrDuplicateKey is returned when an insert would violate a unique constraint
-// (e.g., the unique index on file(externalID, storageBucketId)).
-// Service layer uses this to detect concurrent-creator races.
+// ErrDuplicateKey is returned when an insert would violate any file-table
+// unique constraint. The service disambiguates a dedup winner from an
+// authorizationId/tagsetId collision by probing (externalID, bucket).
 var ErrDuplicateKey = errors.New("duplicate key")

--- a/internal/domain/port/backup_outbox.go
+++ b/internal/domain/port/backup_outbox.go
@@ -17,8 +17,8 @@ import (
 // existing write path, never a behaviour change when disabled.
 type BackupOutboxRepo interface {
 	// CreateWithOutbox inserts a new document and enqueues its backup hint atomically.
-	// Returns model.ErrDuplicateKey on the dedup race (no outbox row written), exactly as
-	// DocumentRepo.Create does, so the service's dedup path is unchanged.
+	// Returns model.ErrDuplicateKey on any document unique violation (no outbox row written),
+	// exactly as DocumentRepo.Create does, so service classification is identical.
 	CreateWithOutbox(ctx context.Context, doc model.Document, contentMetadata model.ContentMetadata, priority int16) (uuid.UUID, error)
 	// UpdateFileWithOutbox replaces a document's content and enqueues a backup hint for the new
 	// content hash atomically, compare-and-set against expectedExternalID and expectedVersion. Same

--- a/internal/domain/service/file_service.go
+++ b/internal/domain/service/file_service.go
@@ -96,7 +96,8 @@ var (
 
 // writeCreate persists a new document — via the transactional outbox path (a backup-outbox row
 // in the same commit, FR-001) when the producer is on and the object is non-temporary, else the
-// original non-transactional Repo.Create. Both return model.ErrDuplicateKey on the dedup race.
+// original non-transactional Repo.Create. Both return model.ErrDuplicateKey on any unique
+// violation; insertDocument classifies it after the write.
 func (s *FileService) writeCreate(ctx context.Context, doc model.Document, meta model.ContentMetadata) error {
 	if s.Outbox != nil && !doc.TemporaryLocation {
 		_, err := s.Outbox.CreateWithOutbox(ctx, doc, meta, s.priorityForMime(doc.MimeType))
@@ -181,6 +182,12 @@ func (s *FileService) findDedupDocument(ctx context.Context, externalID string, 
 // destination bucket already has a row with the same externalID, return
 // it as-is with Reused=true, matching the CreateDocument contract.
 func (s *FileService) CopyDocument(ctx context.Context, sourceID uuid.UUID, input model.CopyDocumentInput) (*model.Document, error) {
+	// Copy always creates a policy-owned logical document. Only the internal
+	// create flow may deliberately omit authorization.
+	if input.AuthorizationID == uuid.Nil {
+		return nil, ErrInvalidAuthorizationID
+	}
+
 	source, err := s.Repo.GetByID(ctx, sourceID)
 	if err != nil {
 		// ErrDocumentNotFound surfaces as 404 in the handler.
@@ -329,20 +336,24 @@ func (s *FileService) insertDocument(ctx context.Context, input model.CreateDocu
 	}
 
 	if errors.Is(err, model.ErrDuplicateKey) {
-		// SkipDedup means the caller explicitly asked for a fresh row. If the
-		// schema enforces unique(externalID, storageBucketID), we can't honor
-		// that intent — surface as ErrConflict rather than masquerading as a
-		// dedup hit (which would silently corrupt placeholder flows).
+		// SkipDedup means the caller explicitly asked for a fresh row. Any
+		// uniqueness failure means that insert cannot be honored; never
+		// masquerade it as a dedup hit and corrupt placeholder flows.
 		if input.SkipDedup {
 			return nil, ErrConflict
 		}
-		// Default path: another concurrent creator won the race on the
-		// unique(externalID, storageBucketID) index. Re-query and return
-		// the winner with Reused=true.
+		// One probe disambiguates the constraint without depending on its
+		// database-generated name: a matching content row is a valid dedup
+		// winner; no match means another unique column collided.
 		raced, findErr := s.Repo.FindByExternalIDAndBucket(ctx, stored.ExternalID, input.StorageBucketID)
 		if findErr == nil {
 			raced.Reused = true
 			return &raced, nil
+		}
+		if errors.Is(findErr, model.ErrDocumentNotFound) {
+			// No content winner exists, so treat this as a non-dedup unique
+			// collision (normally authorizationId or tagsetId).
+			return nil, ErrConflict
 		}
 		s.Logger.Warn("dedup: unique violation but re-query failed",
 			zap.String("externalID", stored.ExternalID), zap.Error(findErr))
@@ -567,10 +578,12 @@ var (
 	// the actor the required privilege. An evaluation that could not run at
 	// all surfaces as a wrapped transport error instead.
 	ErrForbidden = errors.New("forbidden")
-	// ErrConflict covers both flavors of write conflict: an optimistic-lock
-	// version mismatch on metadata updates, and a content-hash collision
-	// when SkipDedup forbids reusing the existing row.
-	ErrConflict = errors.New("conflict: document was modified concurrently")
+	// ErrConflict covers optimistic-lock failures and unique-column collisions
+	// that cannot be satisfied as a valid dedup hit.
+	ErrConflict = errors.New("conflict")
+	// ErrInvalidAuthorizationID rejects copy requests without a real policy ID.
+	// Create may intentionally use uuid.Nil, which persists as SQL NULL.
+	ErrInvalidAuthorizationID = errors.New("authorization ID is required for copy")
 	// ErrPayloadTooLarge rejects an upload exceeding the bucket's maxFileSize
 	// policy (distinct from the transport-level ErrOverLimit cap).
 	ErrPayloadTooLarge = errors.New("payload too large")

--- a/internal/domain/service/file_service_test.go
+++ b/internal/domain/service/file_service_test.go
@@ -43,6 +43,7 @@ type mockRepo struct {
 	countErr      error
 
 	// Captured args from Create / UpdateFile content_metadata params.
+	lastCreateDoc                 model.Document
 	lastCreateContentMetadata     model.ContentMetadata
 	lastUpdateFileContentMetadata model.ContentMetadata
 
@@ -92,6 +93,7 @@ func (m *mockRepo) FindByExternalIDAndBucket(_ context.Context, externalID strin
 }
 func (m *mockRepo) Create(_ context.Context, doc model.Document, contentMetadata model.ContentMetadata) (uuid.UUID, error) {
 	m.createCalls++
+	m.lastCreateDoc = doc
 	m.lastCreateContentMetadata = contentMetadata
 	if m.createErrOnce != nil && m.createCalls == 1 {
 		return uuid.Nil, m.createErrOnce
@@ -307,6 +309,29 @@ func TestCreateDocument_Happy(t *testing.T) {
 	}
 }
 
+func TestCreateDocument_OmittedAuthorizationPersistsNil(t *testing.T) {
+	repo := &mockRepo{}
+	svc := &FileService{
+		Logger:    nopLogger,
+		Repo:      repo,
+		Storage:   &mockStorage{},
+		Processor: &mockProcessor{},
+	}
+
+	doc, err := svc.CreateDocument(context.Background(), model.CreateDocumentInput{
+		DisplayName:     "snapshot.ybin",
+		StorageBucketID: uuid.New(),
+		// AuthorizationID intentionally omitted: internal snapshot rows are
+		// stored with SQL NULL authorization.
+	}, []byte("content"), "", nil, 0)
+	if err != nil {
+		t.Fatalf("CreateDocument: %v", err)
+	}
+	if doc.AuthorizationID != uuid.Nil || repo.lastCreateDoc.AuthorizationID != uuid.Nil {
+		t.Fatalf("authorization = response %s / repo %s, want uuid.Nil", doc.AuthorizationID, repo.lastCreateDoc.AuthorizationID)
+	}
+}
+
 // Dedup: same content in same bucket → existing row returned, Reused=true,
 // caller-supplied auth/tagset ignored.
 func TestCreateDocument_Dedup_SameContentSameBucket_ReturnsExisting(t *testing.T) {
@@ -385,9 +410,9 @@ func TestCreateDocument_Dedup_SameContentDifferentBucket_InsertsNew(t *testing.T
 	}
 }
 
-// Concurrent race: first Create fails with ErrDuplicateKey (other writer
-// won the race on unique(externalID, storageBucketID)). Service re-queries
-// and returns the winner with Reused=true.
+// Defensive content-winner classification: a schema variant reports
+// ErrDuplicateKey and the follow-up (externalID, bucket) probe finds the
+// concurrent row. The service returns that row with Reused=true.
 func TestCreateDocument_Dedup_CreateRace_ReturnsWinnerAsReused(t *testing.T) {
 	winnerID := uuid.New()
 	winnerAuth := uuid.New()
@@ -431,6 +456,53 @@ func TestCreateDocument_Dedup_CreateRace_ReturnsWinnerAsReused(t *testing.T) {
 	}
 	if doc.AuthorizationID != winnerAuth {
 		t.Errorf("AuthorizationID = %v, want winner %v", doc.AuthorizationID, winnerAuth)
+	}
+}
+
+func TestCreateDocument_DuplicateKeyWithoutContentWinnerReturnsConflict(t *testing.T) {
+	repo := &mockRepoRace{
+		find: func() (model.Document, error) {
+			return model.Document{}, model.ErrDocumentNotFound
+		},
+		createErr: model.ErrDuplicateKey,
+	}
+	svc := &FileService{Logger: nopLogger, Repo: repo, Storage: &mockStorage{}, Processor: &mockProcessor{}}
+
+	_, err := svc.CreateDocument(context.Background(), model.CreateDocumentInput{
+		DisplayName:     "snapshot.ybin",
+		StorageBucketID: uuid.New(),
+		AuthorizationID: uuid.New(),
+	}, []byte("content"), "", nil, 0)
+	if !errors.Is(err, ErrConflict) {
+		t.Fatalf("error = %v, want ErrConflict for authorizationId/tagsetId collision", err)
+	}
+}
+
+func TestCreateDocument_DuplicateKeyWinnerLookupFailurePropagates(t *testing.T) {
+	dbErr := errors.New("database unavailable")
+	call := 0
+	repo := &mockRepoRace{
+		find: func() (model.Document, error) {
+			call++
+			if call == 1 {
+				return model.Document{}, model.ErrDocumentNotFound
+			}
+			return model.Document{}, dbErr
+		},
+		createErr: model.ErrDuplicateKey,
+	}
+	svc := &FileService{Logger: nopLogger, Repo: repo, Storage: &mockStorage{}, Processor: &mockProcessor{}}
+
+	_, err := svc.CreateDocument(context.Background(), model.CreateDocumentInput{
+		DisplayName:     "snapshot.ybin",
+		StorageBucketID: uuid.New(),
+		AuthorizationID: uuid.New(),
+	}, []byte("content"), "", nil, 0)
+	if !errors.Is(err, dbErr) {
+		t.Fatalf("error = %v, want wrapped lookup failure", err)
+	}
+	if errors.Is(err, ErrConflict) {
+		t.Fatalf("transport failure must not be classified as a client conflict: %v", err)
 	}
 }
 
@@ -698,6 +770,22 @@ func TestCreateDocument_DBFails_DoesNotDeleteBlob(t *testing.T) {
 
 // CopyDocument: happy path. Source exists in bucket A; copy to bucket B
 // produces a fresh row with same content metadata, caller's auth/tagset.
+func TestCopyDocument_RequiresAuthorization(t *testing.T) {
+	repo := &mockRepo{}
+	svc := &FileService{Logger: nopLogger, Repo: repo}
+
+	_, err := svc.CopyDocument(context.Background(), uuid.New(), model.CopyDocumentInput{
+		DestinationBucketID: uuid.New(),
+		AuthorizationID:     uuid.Nil,
+	})
+	if !errors.Is(err, ErrInvalidAuthorizationID) {
+		t.Fatalf("error = %v, want ErrInvalidAuthorizationID", err)
+	}
+	if repo.createCalls != 0 {
+		t.Fatalf("copy with no authorization must not create a row; calls=%d", repo.createCalls)
+	}
+}
+
 func TestCopyDocument_Happy(t *testing.T) {
 	sourceID := uuid.New()
 	bucketA := uuid.New()

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -358,7 +358,7 @@ paths:
           content:
             application/json; charset=utf-8:
               schema:
-                $ref: '#/components/schemas/skipDedup-requested-but-a-row-with-this-content-already-exists-in-the-destination-bucket'
+                $ref: '#/components/schemas/copy-conflicts-with-an-existing-row'
           description: Conflict
         "500":
           content:


### PR DESCRIPTION
## Problem

The internal create endpoint required a concrete `authorizationId`, but `file.authorizationId` is nullable and unique. Internal high-volume callers such as collaboration snapshot storage need to create multiple rows without minting or reusing authorization policies; reusing one fixed ID collides after the first row.

## Fix

- `POST /internal/file` now accepts an omitted/empty `authorizationId`.
- Omission becomes the domain's explicit `uuid.Nil` sentinel and persists as SQL `NULL`.
- An explicitly supplied all-zero UUID remains invalid (400), so caller mistakes are not silently converted into unprotected rows.
- The nullable mapping lives in the shared `createDocumentParams` helper, so ordinary `Create` and transactional `CreateWithOutbox` cannot drift.
- `Copy` still requires a real authorization policy ID; the service enforces this invariant and the handler returns 400.
- On `ErrDuplicateKey`, the service probes `(externalID, bucket)` exactly once:
  - hit → valid dedup winner, return `Reused=true`;
  - not found → non-dedup unique collision (normally `authorizationId` / `tagsetId`), return 409;
  - lookup/backend error → propagate as a server failure.

There is no retry, sleep, or synthetic commit-visibility model from #49. PostgreSQL does not expose the claimed post-unique-violation visibility window here, and this repository's schema has no `(externalID, storageBucketId)` unique constraint.

## Compatibility

The standard server upload path continues supplying a freshly minted authorization policy ID. The wire schema and generated OpenAPI are unchanged. Existing reads map a NULL authorization column to `uuid.Nil`, as before.

## Validation

- `make test` — race-enabled stub suite, 77.7% overall coverage
- `make test-vips` — race-enabled native image suite, 78.5% overall coverage
- `make lint` — 0 issues
- `go vet ./...`
- `make build-stub` and `make build`
- `make sqlc-generate` and `make openapi` — idempotent
- targeted tests cover omitted/explicit-zero authorization, plain + outbox mapping, Copy's required-auth invariant, dedup winner/conflict/backend-error classification, and HTTP 201/400/409 mappings

Supersedes #49.

<!-- pr-image-report:start -->
---
### 📦 PR image — test the current state of this PR

```bash
docker pull ghcr.io/alkem-io/file-service:pr-50
```

Current build: `ghcr.io/alkem-io/file-service:pr-50-4294f62` · `linux/amd64` + `linux/arm64` · index digest `sha256:fa3f386ef5a70f6c4fc17f428d2f57952c806af6f83fc51bec41a849be1680ac`
<!-- pr-image-report:end -->
