### PR TITLE
feat(content-batch): batched internal content-read endpoint (006-collab-content-unification)

### DIFF
--- a/internal/adapter/inbound/http/content_batch_handler.go
+++ b/internal/adapter/inbound/http/content_batch_handler.go
@@ -1,0 +1,117 @@
+package http
+
+import (
+	"encoding/base64"
+	"errors"
+	"net/http"
+
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+
+	"github.com/alkem-io/file-service/internal/domain/model"
+	"github.com/alkem-io/file-service/internal/domain/service"
+)
+
+// maxContentBatchSize bounds how many ids one content-batch request may carry.
+// Each id costs a document lookup plus a blob read, so an unbounded list would
+// let a single request fan out into an arbitrarily large burst of DB + storage
+// work. 256 comfortably covers the derived-text resolver's real fan-in (a page
+// of memo previews) while capping the per-request blast radius; callers with
+// more ids page the request.
+const maxContentBatchSize = 256
+
+// ContentBatch handles POST /internal/file/content-batch — the batched
+// counterpart to GET /internal/file/{id}/content. It takes N document ids and
+// returns N content blobs (base64) in request order, so the server's
+// derived-text resolvers can read a list of snapshot pointers in one round trip
+// instead of an N+1 of single reads.
+//
+// Per-id failures are non-fatal: a malformed id, a missing document, or a
+// missing blob is reported as found=false on that item while the rest of the
+// batch still resolves — the endpoint returns 200 as long as the request itself
+// is well-formed. Wired with the same internal (no-auth) middleware as the
+// other /internal/file routes; per-blob authorization does not apply (these are
+// NULL-authz internal snapshot blobs governed by the owning document).
+func (h *DocumentHandler) ContentBatch(w http.ResponseWriter, r *http.Request) {
+	var body ContentBatchRequest
+	if !decodeStrictJSON(w, r, &body) {
+		return
+	}
+
+	if len(body.Ids) == 0 {
+		writeJSONError(w, http.StatusBadRequest, "ids must not be empty")
+		return
+	}
+	if len(body.Ids) > maxContentBatchSize {
+		writeJSONError(w, http.StatusBadRequest, "too many ids in one batch")
+		return
+	}
+
+	// Parse every requested id up front, preserving request order. Valid ids
+	// are collected into validIDs (passed to the service); a nil parsed pointer
+	// marks a position whose raw id was malformed — reported as a non-fatal
+	// miss without a service lookup.
+	type parsedID struct {
+		raw    string
+		parsed *uuid.UUID
+	}
+	parsed := make([]parsedID, len(body.Ids))
+	validIDs := make([]uuid.UUID, 0, len(body.Ids))
+	for i, raw := range body.Ids {
+		id, err := uuid.Parse(raw)
+		if err != nil {
+			parsed[i] = parsedID{raw: raw}
+			continue
+		}
+		parsed[i] = parsedID{raw: raw, parsed: &id}
+		validIDs = append(validIDs, id)
+	}
+
+	results := h.Service.ReadContentBatch(r.Context(), validIDs)
+
+	items := make([]ContentBatchItem, len(parsed))
+	resultIdx := 0
+	for i, p := range parsed {
+		if p.parsed == nil {
+			items[i] = ContentBatchItem{ID: p.raw, Found: false, Error: "invalid id"}
+			continue
+		}
+		items[i] = h.batchItem(p.raw, results[resultIdx])
+		resultIdx++
+	}
+
+	ContentBatchResponse{Items: items}.Render(w)
+}
+
+// batchItem maps one service-layer BatchContentResult to its wire item: a hit
+// carries the base64 blob + MIME; a miss carries a stable, caller-safe reason
+// (the raw error may name internal storage paths, so it is logged, not
+// returned). A genuine storage failure is logged at Warn for observability; a
+// not-found row is an expected, silent miss (the caller's pointer simply has no
+// snapshot yet).
+func (h *DocumentHandler) batchItem(rawID string, res service.BatchContentResult) ContentBatchItem {
+	if res.Found {
+		return ContentBatchItem{
+			ID:            rawID,
+			Found:         true,
+			MimeType:      res.MimeType,
+			ContentBase64: base64.StdEncoding.EncodeToString(res.Content),
+		}
+	}
+	if res.Err != nil && !errors.Is(res.Err, model.ErrDocumentNotFound) {
+		h.Logger.Warn("content-batch: content read failed for id",
+			zap.String("id", rawID), zap.Error(res.Err))
+	}
+	return ContentBatchItem{ID: rawID, Found: false, Error: batchMissReason(res.Err)}
+}
+
+// batchMissReason renders a stable, caller-safe reason for a non-fatal miss.
+// A not-found row is "document not found"; anything else (e.g. a storage read
+// failure that may embed an internal path) collapses to the generic
+// "content unavailable" so the body never leaks internals.
+func batchMissReason(err error) string {
+	if errors.Is(err, model.ErrDocumentNotFound) {
+		return "document not found"
+	}
+	return "content unavailable"
+}

--- a/internal/adapter/inbound/http/content_batch_test.go
+++ b/internal/adapter/inbound/http/content_batch_test.go
@@ -1,0 +1,328 @@
+package http
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+
+	"github.com/alkem-io/file-service/internal/domain/model"
+)
+
+// runContentBatch wires a fresh handler + chi router and dispatches a single
+// POST /internal/file/content-batch request with the given JSON body. The
+// configure callback (if non-nil) seeds mock state on the repo + storage
+// before the request is served. Returns the response recorder so callers can
+// assert status + body without repeating chi/httptest boilerplate.
+func runContentBatch(t *testing.T, body string, configure func(*mockDocRepo, *mockStorage)) *httptest.ResponseRecorder {
+	t.Helper()
+	h, repo, storage := newDocHandler()
+	if configure != nil {
+		configure(repo, storage)
+	}
+	r := chi.NewRouter()
+	r.Post("/internal/file/content-batch", h.ContentBatch)
+
+	req := httptest.NewRequest(http.MethodPost, "/internal/file/content-batch", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+	return rr
+}
+
+func decodeBatchResponse(t *testing.T, rr *httptest.ResponseRecorder) ContentBatchResponse {
+	t.Helper()
+	var resp ContentBatchResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v (body: %s)", err, rr.Body.String())
+	}
+	return resp
+}
+
+// Happy path: every requested id resolves to its own blob, decoded from the
+// base64 payload. This is the core derived-text-resolver use case (N memo
+// snapshot pointers → N snapshot blobs in one round trip).
+func TestContentBatch_ReturnsEachBlob(t *testing.T) {
+	id1, id2 := uuid.New(), uuid.New()
+	want := map[uuid.UUID]string{id1: "snapshot-one", id2: "snapshot-two"}
+
+	rr := runContentBatch(t, `{"ids":["`+id1.String()+`","`+id2.String()+`"]}`, func(repo *mockDocRepo, storage *mockStorage) {
+		repo.docsByID = map[uuid.UUID]model.Document{
+			id1: {ID: id1, ExternalID: "ext-1", MimeType: "application/octet-stream"},
+			id2: {ID: id2, ExternalID: "ext-2", MimeType: "text/plain"},
+		}
+		storage.blobsByExternalID = map[string][]byte{
+			"ext-1": []byte(want[id1]),
+			"ext-2": []byte(want[id2]),
+		}
+	})
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200, body: %s", rr.Code, rr.Body.String())
+	}
+	resp := decodeBatchResponse(t, rr)
+	if len(resp.Items) != 2 {
+		t.Fatalf("len(items) = %d, want 2", len(resp.Items))
+	}
+	for _, item := range resp.Items {
+		id := uuid.MustParse(item.ID)
+		if !item.Found {
+			t.Errorf("id %s: found = false, want true", id)
+			continue
+		}
+		decoded, err := base64.StdEncoding.DecodeString(item.ContentBase64)
+		if err != nil {
+			t.Errorf("id %s: base64 decode: %v", id, err)
+			continue
+		}
+		if string(decoded) != want[id] {
+			t.Errorf("id %s: content = %q, want %q", id, decoded, want[id])
+		}
+	}
+}
+
+// MIME type is carried through per item so the caller can decode the blob in
+// the right context.
+func TestContentBatch_CarriesMimeType(t *testing.T) {
+	id := uuid.New()
+	rr := runContentBatch(t, `{"ids":["`+id.String()+`"]}`, func(repo *mockDocRepo, storage *mockStorage) {
+		repo.docsByID = map[uuid.UUID]model.Document{
+			id: {ID: id, ExternalID: "ext", MimeType: "application/x-yjs-snapshot"},
+		}
+		storage.blobsByExternalID = map[string][]byte{"ext": []byte("data")}
+	})
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	resp := decodeBatchResponse(t, rr)
+	if len(resp.Items) != 1 {
+		t.Fatalf("len(items) = %d, want 1", len(resp.Items))
+	}
+	if resp.Items[0].MimeType != "application/x-yjs-snapshot" {
+		t.Errorf("mimeType = %q, want application/x-yjs-snapshot", resp.Items[0].MimeType)
+	}
+}
+
+// Order MUST be preserved: items[i] corresponds to the i-th requested id, even
+// when ids repeat and even when a duplicate maps to the same row. The caller
+// relies on positional correspondence (no per-item id matching) for its
+// resolver fan-in.
+func TestContentBatch_PreservesOrder(t *testing.T) {
+	a, b, c := uuid.New(), uuid.New(), uuid.New()
+	// Deliberately request out of "natural" order, with a repeat (a appears twice).
+	order := []uuid.UUID{c, a, b, a}
+	quoted := make([]string, len(order))
+	for i, id := range order {
+		quoted[i] = `"` + id.String() + `"`
+	}
+
+	rr := runContentBatch(t, `{"ids":[`+strings.Join(quoted, ",")+`]}`, func(repo *mockDocRepo, storage *mockStorage) {
+		repo.docsByID = map[uuid.UUID]model.Document{
+			a: {ID: a, ExternalID: "ext-a", MimeType: "text/plain"},
+			b: {ID: b, ExternalID: "ext-b", MimeType: "text/plain"},
+			c: {ID: c, ExternalID: "ext-c", MimeType: "text/plain"},
+		}
+		storage.blobsByExternalID = map[string][]byte{
+			"ext-a": []byte("AAA"),
+			"ext-b": []byte("BBB"),
+			"ext-c": []byte("CCC"),
+		}
+	})
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200, body: %s", rr.Code, rr.Body.String())
+	}
+	resp := decodeBatchResponse(t, rr)
+	if len(resp.Items) != len(order) {
+		t.Fatalf("len(items) = %d, want %d (one per requested id, duplicates preserved)", len(resp.Items), len(order))
+	}
+	for i, item := range resp.Items {
+		wantID := order[i]
+		if item.ID != wantID.String() {
+			t.Errorf("items[%d].id = %s, want %s (order not preserved)", i, item.ID, wantID)
+		}
+	}
+}
+
+// Missing ids are reported non-fatally: an unknown document id (or one whose
+// blob is gone from storage) yields found=false for that item while the rest
+// of the batch still resolves. The endpoint never 404s for a partial miss —
+// that is the whole point of a batch read feeding a best-effort resolver.
+func TestContentBatch_MissingReportedNonFatally(t *testing.T) {
+	present := uuid.New()
+	unknownDoc := uuid.New()  // no repo row
+	blobMissing := uuid.New() // repo row exists, blob absent from storage
+	order := []uuid.UUID{present, unknownDoc, blobMissing}
+	quoted := make([]string, len(order))
+	for i, id := range order {
+		quoted[i] = `"` + id.String() + `"`
+	}
+
+	rr := runContentBatch(t, `{"ids":[`+strings.Join(quoted, ",")+`]}`, func(repo *mockDocRepo, storage *mockStorage) {
+		repo.docsByID = map[uuid.UUID]model.Document{
+			present:     {ID: present, ExternalID: "ext-present", MimeType: "text/plain"},
+			blobMissing: {ID: blobMissing, ExternalID: "ext-gone", MimeType: "text/plain"},
+			// unknownDoc intentionally absent → GetByID returns ErrDocumentNotFound.
+		}
+		storage.blobsByExternalID = map[string][]byte{
+			"ext-present": []byte("here"),
+			// "ext-gone" intentionally absent → Read returns os.ErrNotExist.
+		}
+	})
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (partial miss is non-fatal), body: %s", rr.Code, rr.Body.String())
+	}
+	resp := decodeBatchResponse(t, rr)
+	if len(resp.Items) != 3 {
+		t.Fatalf("len(items) = %d, want 3", len(resp.Items))
+	}
+
+	if !resp.Items[0].Found || resp.Items[0].ContentBase64 == "" {
+		t.Errorf("items[0] (present) found=%v content=%q, want found + content", resp.Items[0].Found, resp.Items[0].ContentBase64)
+	}
+	for i, label := range map[int]string{1: "unknown-doc", 2: "blob-missing"} {
+		if resp.Items[i].Found {
+			t.Errorf("items[%d] (%s) found = true, want false", i, label)
+		}
+		if resp.Items[i].Error == "" {
+			t.Errorf("items[%d] (%s) error empty, want a non-fatal reason", i, label)
+		}
+		if resp.Items[i].ContentBase64 != "" {
+			t.Errorf("items[%d] (%s) content non-empty on a miss", i, label)
+		}
+	}
+}
+
+// A syntactically invalid id inside the batch is reported as a non-fatal miss
+// for that position — the well-formed ids still resolve. The endpoint does not
+// reject the whole request for one bad id.
+func TestContentBatch_InvalidIDInBatchNonFatal(t *testing.T) {
+	good := uuid.New()
+	rr := runContentBatch(t, `{"ids":["`+good.String()+`","not-a-uuid"]}`, func(repo *mockDocRepo, storage *mockStorage) {
+		repo.docsByID = map[uuid.UUID]model.Document{
+			good: {ID: good, ExternalID: "ext", MimeType: "text/plain"},
+		}
+		storage.blobsByExternalID = map[string][]byte{"ext": []byte("ok")}
+	})
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200, body: %s", rr.Code, rr.Body.String())
+	}
+	resp := decodeBatchResponse(t, rr)
+	if len(resp.Items) != 2 {
+		t.Fatalf("len(items) = %d, want 2", len(resp.Items))
+	}
+	if !resp.Items[0].Found {
+		t.Errorf("items[0] (valid id) found = false, want true")
+	}
+	if resp.Items[0].ID != good.String() {
+		t.Errorf("items[0].id = %s, want %s", resp.Items[0].ID, good)
+	}
+	if resp.Items[1].Found {
+		t.Errorf("items[1] (invalid id) found = true, want false")
+	}
+	if resp.Items[1].ID != "not-a-uuid" {
+		t.Errorf("items[1].id = %q, want the malformed id echoed back", resp.Items[1].ID)
+	}
+	if resp.Items[1].Error == "" {
+		t.Errorf("items[1] (invalid id) error empty, want a reason")
+	}
+}
+
+// A single id is a valid batch of one — the endpoint behaves identically to
+// the single-read path it reuses.
+func TestContentBatch_SingleID(t *testing.T) {
+	id := uuid.New()
+	rr := runContentBatch(t, `{"ids":["`+id.String()+`"]}`, func(repo *mockDocRepo, storage *mockStorage) {
+		repo.docsByID = map[uuid.UUID]model.Document{id: {ID: id, ExternalID: "ext", MimeType: "text/plain"}}
+		storage.blobsByExternalID = map[string][]byte{"ext": []byte("solo")}
+	})
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	resp := decodeBatchResponse(t, rr)
+	if len(resp.Items) != 1 || !resp.Items[0].Found {
+		t.Fatalf("items = %+v, want one found item", resp.Items)
+	}
+	decoded, _ := base64.StdEncoding.DecodeString(resp.Items[0].ContentBase64)
+	if string(decoded) != "solo" {
+		t.Errorf("content = %q, want %q", decoded, "solo")
+	}
+}
+
+// An empty ids array is a client error (nothing to read) → 400, distinguishing
+// "you asked for nothing" from "everything you asked for was missing" (200 with
+// found=false items).
+func TestContentBatch_EmptyIDs_400(t *testing.T) {
+	rr := runContentBatch(t, `{"ids":[]}`, nil)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 for empty ids", rr.Code)
+	}
+}
+
+// A missing ids field is the same client error as an empty array.
+func TestContentBatch_OmittedIDs_400(t *testing.T) {
+	rr := runContentBatch(t, `{}`, nil)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 for omitted ids", rr.Code)
+	}
+}
+
+// The batch size is bounded to protect the service from an unbounded fan-out of
+// per-id DB+storage reads in a single request; over the cap → 400.
+func TestContentBatch_TooManyIDs_400(t *testing.T) {
+	ids := make([]string, maxContentBatchSize+1)
+	for i := range ids {
+		ids[i] = `"` + uuid.New().String() + `"`
+	}
+	rr := runContentBatch(t, `{"ids":[`+strings.Join(ids, ",")+`]}`, nil)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 for over-cap batch", rr.Code)
+	}
+}
+
+// Exactly the cap is accepted (boundary).
+func TestContentBatch_AtCap_OK(t *testing.T) {
+	ids := make([]string, maxContentBatchSize)
+	for i := range ids {
+		ids[i] = `"` + uuid.New().String() + `"`
+	}
+	// No docs seeded → every item resolves as a non-fatal miss, but the
+	// request itself is accepted (200), which is what this boundary asserts.
+	rr := runContentBatch(t, `{"ids":[`+strings.Join(ids, ",")+`]}`, func(repo *mockDocRepo, _ *mockStorage) {
+		repo.docsByID = map[uuid.UUID]model.Document{} // empty, id-aware → all miss
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 at exactly the cap, body: %s", rr.Code, rr.Body.String())
+	}
+	resp := decodeBatchResponse(t, rr)
+	if len(resp.Items) != maxContentBatchSize {
+		t.Fatalf("len(items) = %d, want %d", len(resp.Items), maxContentBatchSize)
+	}
+}
+
+// Malformed JSON body → 400.
+func TestContentBatch_MalformedJSON_400(t *testing.T) {
+	rr := runContentBatch(t, `{"ids":[`, nil)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 for malformed JSON", rr.Code)
+	}
+}
+
+// Unknown fields in the body → 400 (strict decode), matching the other
+// JSON-bodied internal endpoints (Copy, Update).
+func TestContentBatch_UnknownField_400(t *testing.T) {
+	id := uuid.New()
+	rr := runContentBatch(t, `{"ids":["`+id.String()+`"],"surprise":true}`, nil)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 for unknown field", rr.Code)
+	}
+}

--- a/internal/adapter/inbound/http/document_handler.go
+++ b/internal/adapter/inbound/http/document_handler.go
@@ -174,9 +174,14 @@ func buildCreateInput(fields createFields) (input model.CreateDocumentInput, all
 		return input, nil, 0, fmt.Errorf("invalid storageBucketId")
 	}
 
-	authorizationID, err := uuid.Parse(fields.authorizationID)
+	// authorizationId is OPTIONAL: an internal caller (e.g. the collaboration
+	// snapshot store) omits it so the row's authz column is NULL. file's
+	// authorizationId carries a UNIQUE constraint, so callers that need many
+	// rows in one bucket (snapshots) MUST leave it empty rather than reuse a
+	// single fixed id.
+	authorizationID, err := parseOptionalUUID(fields.authorizationID, "authorizationId")
 	if err != nil {
-		return input, nil, 0, fmt.Errorf("invalid authorizationId")
+		return input, nil, 0, err
 	}
 
 	tagsetID, err := parseOptionalUUID(fields.tagsetID, "tagsetId")

--- a/internal/adapter/inbound/http/document_handler_test.go
+++ b/internal/adapter/inbound/http/document_handler_test.go
@@ -256,6 +256,35 @@ func TestDocumentHandler_Create_Success(t *testing.T) {
 	}
 }
 
+// An internal caller (e.g. the collaboration snapshot store) may omit the
+// authorizationId multipart field entirely. The create MUST accept it (the row
+// gets NULL authz) rather than reject it as "invalid authorizationId" — that
+// rejection is what previously crashed snapshot persistence.
+func TestDocumentHandler_Create_Success_OmittedAuthorizationId(t *testing.T) {
+	h, _, _ := newDocHandler()
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	part, _ := writer.CreateFormFile("file", "snapshot.ybin")
+	_, _ = part.Write([]byte("hello"))
+	_ = writer.WriteField("displayName", "collaboration-snapshot")
+	_ = writer.WriteField("storageBucketId", uuid.New().String())
+	// authorizationId deliberately omitted → NULL authz column.
+	_ = writer.Close()
+
+	r := chi.NewRouter()
+	r.Post("/internal/file", h.Create)
+
+	req := httptest.NewRequest(http.MethodPost, "/internal/file", &body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201 (omitted authz accepted), body: %s", rr.Code, rr.Body.String())
+	}
+}
+
 func TestDocumentHandler_Create_Success_NotReused(t *testing.T) {
 	h, _, _ := newDocHandler()
 

--- a/internal/adapter/inbound/http/dto.go
+++ b/internal/adapter/inbound/http/dto.go
@@ -143,6 +143,44 @@ type UpdateDocumentRequest struct {
 	DisplayName       *string `json:"displayName,omitempty"`
 }
 
+// ContentBatchRequest is the JSON body for POST /internal/file/content-batch.
+// Ids is a list (not a set): order is significant and duplicates are honored,
+// so the response items line up positionally with what the caller sent.
+type ContentBatchRequest struct {
+	Ids []string `json:"ids"`
+}
+
+// ContentBatchItem is one entry of a ContentBatchResponse, positionally aligned
+// with the requested ids. Found reports whether the document's content was
+// retrieved: when true, MimeType + ContentBase64 carry the blob; when false,
+// Error gives the non-fatal reason (malformed id, document not found, blob
+// missing) and the content fields are empty. Id echoes the requested value
+// verbatim — including a syntactically invalid one — so the caller can
+// correlate by value as well as by position.
+type ContentBatchItem struct {
+	ID            string `json:"id"`
+	Found         bool   `json:"found"`
+	MimeType      string `json:"mimeType,omitempty"`
+	ContentBase64 string `json:"contentBase64,omitempty"`
+	Error         string `json:"error,omitempty"`
+}
+
+// ContentBatchResponse is returned by POST /internal/file/content-batch: one
+// item per requested id, in request order. The endpoint returns 200 even when
+// every item is a miss — a partial or total miss is reported per item, not as
+// an HTTP error (the request itself was well-formed). Blobs are base64-encoded
+// so binary content (e.g. Yjs-V2 snapshots) rides safely in JSON.
+type ContentBatchResponse struct {
+	Items []ContentBatchItem `json:"items"`
+}
+
+// Render writes the response as JSON with HTTP 200.
+func (r ContentBatchResponse) Render(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(r)
+}
+
 // CopyDocumentRequest is the JSON body for POST /internal/file/copy.
 // Reuses CreateDocumentResponse for the response shape.
 type CopyDocumentRequest struct {

--- a/internal/adapter/inbound/http/public_handler_test.go
+++ b/internal/adapter/inbound/http/public_handler_test.go
@@ -30,6 +30,13 @@ type mockDocRepo struct {
 	deleteErr    error
 	count        int
 
+	// docsByID, when non-nil, makes GetByID id-aware: it returns the mapped
+	// document for a known id and model.ErrDocumentNotFound for an unknown
+	// one. Used by the batched-read tests, which need several distinct rows
+	// in one request. When nil, GetByID falls back to the single doc/err
+	// pair above so every existing single-document test is unaffected.
+	docsByID map[uuid.UUID]model.Document
+
 	// Captured args from the most recent UpdateMetadata call.
 	updateMetadataCalls   int
 	lastUpdateBucketID    uuid.UUID
@@ -49,7 +56,13 @@ type mockDocRepo struct {
 	backfillErr            error
 }
 
-func (m *mockDocRepo) GetByID(_ context.Context, _ uuid.UUID) (model.Document, error) {
+func (m *mockDocRepo) GetByID(_ context.Context, id uuid.UUID) (model.Document, error) {
+	if m.docsByID != nil {
+		if doc, ok := m.docsByID[id]; ok {
+			return doc, nil
+		}
+		return model.Document{}, model.ErrDocumentNotFound
+	}
 	return m.doc, m.err
 }
 func (m *mockDocRepo) FindByExternalIDAndBucket(_ context.Context, _ string, _ uuid.UUID) (model.Document, error) {
@@ -127,6 +140,14 @@ type mockStorage struct {
 	saveErr error
 	saved   []byte // captures the last Save/stage payload (replace-path rejection tests)
 	stages  []*httpMockStage
+
+	// blobsByExternalID, when non-nil, makes Read externalID-aware: it returns
+	// the mapped bytes for a known externalID and os.ErrNotExist for an
+	// unknown one. Used by the batched-read tests so distinct documents map to
+	// distinct blobs (and a "missing blob" case is expressible). When nil,
+	// Read falls back to the single data/err pair so existing tests are
+	// unaffected.
+	blobsByExternalID map[string][]byte
 }
 
 func (m *mockStorage) Save(content []byte) (model.StoredFile, error) {
@@ -136,7 +157,15 @@ func (m *mockStorage) Save(content []byte) (model.StoredFile, error) {
 	}
 	return model.StoredFile{ExternalID: "hash", Size: len(content), Created: true}, nil
 }
-func (m *mockStorage) Read(_ string) ([]byte, error) { return m.data, m.err }
+func (m *mockStorage) Read(externalID string) ([]byte, error) {
+	if m.blobsByExternalID != nil {
+		if b, ok := m.blobsByExternalID[externalID]; ok {
+			return b, nil
+		}
+		return nil, os.ErrNotExist
+	}
+	return m.data, m.err
+}
 func (m *mockStorage) Delete(_ string) error         { return nil }
 func (m *mockStorage) Exists(_ string) (bool, error) { return m.data != nil, nil }
 

--- a/internal/adapter/inbound/http/router.go
+++ b/internal/adapter/inbound/http/router.go
@@ -66,6 +66,7 @@ func NewRouter(deps Deps) *chi.Mux {
 	r.Route("/internal", func(r chi.Router) {
 		r.Post("/file", deps.DocumentHandler.Create)
 		r.Post("/file/copy", deps.DocumentHandler.Copy)
+		r.Post("/file/content-batch", deps.DocumentHandler.ContentBatch)
 		r.Get("/file/{id}/meta", deps.DocumentHandler.GetMeta)
 		r.Get("/file/{id}/content", deps.DocumentHandler.GetContent)
 		r.Put("/file/{id}/content", deps.DocumentHandler.ReplaceContent)

--- a/internal/adapter/inbound/http/router_test.go
+++ b/internal/adapter/inbound/http/router_test.go
@@ -197,6 +197,30 @@ func TestRouter_InternalDeleteDocument(t *testing.T) {
 	}
 }
 
+// POST /internal/file/content-batch must be registered under the same internal
+// (no-auth) route group as the other /internal/file endpoints. A well-formed
+// batch resolves to 200 through the full router (global middleware + no actor
+// header), confirming the wiring — not just that the route exists.
+func TestRouter_InternalContentBatch(t *testing.T) {
+	r := testRouter()
+
+	body := `{"ids":["` + uuid.New().String() + `"]}`
+	req := httptest.NewRequest(http.MethodPost, "/internal/file/content-batch", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	if rr.Code == http.StatusNotFound || rr.Code == http.StatusMethodNotAllowed {
+		t.Fatalf("POST /internal/file/content-batch = %d, route not registered", rr.Code)
+	}
+	// testRouter seeds a doc + blob and no auth on /internal, so a well-formed
+	// batch returns 200 (the single seeded row resolves; the point is the
+	// internal middleware chain let it through without an actor header).
+	if rr.Code != http.StatusOK {
+		t.Errorf("POST /internal/file/content-batch = %d, want 200 (no-auth internal route)", rr.Code)
+	}
+}
+
 func TestRouter_InternalPatchDocument(t *testing.T) {
 	r := testRouter()
 

--- a/internal/adapter/outbound/alkemiodb/adapter.go
+++ b/internal/adapter/outbound/alkemiodb/adapter.go
@@ -79,11 +79,15 @@ func (a *Adapter) Create(ctx context.Context, doc model.Document, contentMetadat
 		CreatedBy:         uuidToPgxNullable(doc.CreatedBy),
 		TemporaryLocation: doc.TemporaryLocation,
 		StorageBucketId:   uuidToPgx(doc.StorageBucketID),
-		AuthorizationId:   uuidToPgx(doc.AuthorizationID),
-		TagsetId:          uuidToPgxNullable(doc.TagsetID),
-		CreatedDate:       timeToPgx(doc.CreatedDate),
-		UpdatedDate:       timeToPgx(doc.UpdatedDate),
-		ContentMetadata:   raw,
+		// uuid.Nil authz → NULL column (no authorization_policy row to reference;
+		// the FK requires a real id or NULL). Multiple NULLs are permitted by
+		// UNIQUE(authorizationId), which is what lets many snapshots coexist in
+		// one bucket. A real (non-nil) authz writes through unchanged.
+		AuthorizationId: uuidToPgxNullableNil(doc.AuthorizationID),
+		TagsetId:        uuidToPgxNullable(doc.TagsetID),
+		CreatedDate:     timeToPgx(doc.CreatedDate),
+		UpdatedDate:     timeToPgx(doc.UpdatedDate),
+		ContentMetadata: raw,
 	})
 	if err != nil {
 		var pgErr *pgconn.PgError

--- a/internal/adapter/outbound/alkemiodb/convert.go
+++ b/internal/adapter/outbound/alkemiodb/convert.go
@@ -50,6 +50,18 @@ func uuidToPgxNullable(id *uuid.UUID) pgtype.UUID {
 	return pgtype.UUID{Bytes: *id, Valid: true}
 }
 
+// uuidToPgxNullableNil maps a value-typed UUID to a nullable column, treating
+// uuid.Nil (the zero value) as SQL NULL. Used for authorizationId: the model
+// carries it as a value, but an absent authz must persist as NULL (the FK
+// to authorization_policy forbids a dangling all-zero id, and UNIQUE permits
+// multiple NULLs).
+func uuidToPgxNullableNil(id uuid.UUID) pgtype.UUID {
+	if id == uuid.Nil {
+		return pgtype.UUID{Valid: false}
+	}
+	return pgtype.UUID{Bytes: id, Valid: true}
+}
+
 func pgxToUUID(id pgtype.UUID) uuid.UUID {
 	if !id.Valid {
 		return uuid.Nil

--- a/internal/adapter/outbound/alkemiodb/convert_test.go
+++ b/internal/adapter/outbound/alkemiodb/convert_test.go
@@ -35,6 +35,27 @@ func TestUuidToPgxNullable_NonNil(t *testing.T) {
 	}
 }
 
+func TestUuidToPgxNullableNil_Nil(t *testing.T) {
+	// uuid.Nil (the value-typed zero) MUST map to a NULL column so an absent
+	// authorizationId persists as NULL — UNIQUE(authorizationId) permits any
+	// number of NULLs, which is what lets many snapshots coexist in one bucket.
+	pgxID := uuidToPgxNullableNil(uuid.Nil)
+	if pgxID.Valid {
+		t.Error("expected Valid=false (NULL) for uuid.Nil")
+	}
+}
+
+func TestUuidToPgxNullableNil_NonNil(t *testing.T) {
+	id := uuid.New()
+	pgxID := uuidToPgxNullableNil(id)
+	if !pgxID.Valid {
+		t.Error("expected Valid=true for a real id")
+	}
+	if pgxID.Bytes != id {
+		t.Error("bytes mismatch")
+	}
+}
+
 func TestPgxToUUID_Valid(t *testing.T) {
 	id := uuid.New()
 	pgxID := pgtype.UUID{Bytes: id, Valid: true}

--- a/internal/domain/model/document.go
+++ b/internal/domain/model/document.go
@@ -78,8 +78,12 @@ type CreateDocumentInput struct {
 	CreatedBy         *uuid.UUID
 	TemporaryLocation bool
 	StorageBucketID   uuid.UUID
-	AuthorizationID   uuid.UUID
-	TagsetID          *uuid.UUID
+	// AuthorizationID is optional (nil = NULL authz column). file's
+	// authorizationId is UNIQUE, so callers needing many rows in one bucket
+	// (e.g. collaboration snapshots) leave it nil; the standard server upload
+	// path always supplies a freshly-minted authorization_policy id.
+	AuthorizationID *uuid.UUID
+	TagsetID        *uuid.UUID
 
 	// SkipDedup, when true, bypasses the per-bucket content-hash dedup
 	// lookup and forces a fresh row insert even if an existing row in the

--- a/internal/domain/model/errors.go
+++ b/internal/domain/model/errors.go
@@ -5,7 +5,11 @@ import "errors"
 // ErrDocumentNotFound is returned when a document cannot be found in the repository.
 var ErrDocumentNotFound = errors.New("document not found")
 
-// ErrDuplicateKey is returned when an insert would violate a unique constraint
-// (e.g., the unique index on file(externalID, storageBucketId)).
-// Service layer uses this to detect concurrent-creator races.
+// ErrDuplicateKey is returned when an insert violates a UNIQUE constraint on
+// the file table — the per-bucket content-dedup index on (externalID,
+// storageBucketId) where the schema defines it, OR the UNIQUE(authorizationId)
+// / UNIQUE(tagsetId) columns. The adapter cannot tell these apart portably
+// (TypeORM names them with opaque REL_* hashes), so the service layer
+// disambiguates by re-querying the (externalID, bucket) dedup scope: a hit is
+// the content race; a miss means an authorizationId/tagsetId collision.
 var ErrDuplicateKey = errors.New("duplicate key")

--- a/internal/domain/service/create_ooxml_central_dir_test.go
+++ b/internal/domain/service/create_ooxml_central_dir_test.go
@@ -152,7 +152,7 @@ func completeStagedZip(t *testing.T, content []byte, allowed []string) (*model.D
 	if su.DetectedMIME != "application/zip" {
 		t.Fatalf("precondition: DetectedMIME = %q, want application/zip", su.DetectedMIME)
 	}
-	input := model.CreateDocumentInput{DisplayName: "deck.pptx", StorageBucketID: uuid.New(), AuthorizationID: uuid.New()}
+	input := model.CreateDocumentInput{DisplayName: "deck.pptx", StorageBucketID: uuid.New(), AuthorizationID: ptrUUID(uuid.New())}
 	doc, err := svc.CompleteUpload(context.Background(), su, input, allowed, 0)
 	return doc, storage, err
 }
@@ -231,7 +231,7 @@ func TestCompleteUpload_StagedReaderErrorSkipsRecovery(t *testing.T) {
 		if err != nil {
 			t.Fatalf("StageUpload: %v", err)
 		}
-		input := model.CreateDocumentInput{DisplayName: "deck.pptx", StorageBucketID: uuid.New(), AuthorizationID: uuid.New()}
+		input := model.CreateDocumentInput{DisplayName: "deck.pptx", StorageBucketID: uuid.New(), AuthorizationID: ptrUUID(uuid.New())}
 		doc, err := svc.CompleteUpload(context.Background(), su, input, []string{"application/zip"}, 0)
 		if err != nil {
 			t.Fatalf("CompleteUpload: %v, want accepted (recovery skipped, not a hard error)", err)
@@ -250,7 +250,7 @@ func TestCompleteUpload_StagedReaderErrorSkipsRecovery(t *testing.T) {
 		if err != nil {
 			t.Fatalf("StageUpload: %v", err)
 		}
-		input := model.CreateDocumentInput{DisplayName: "deck.pptx", StorageBucketID: uuid.New(), AuthorizationID: uuid.New()}
+		input := model.CreateDocumentInput{DisplayName: "deck.pptx", StorageBucketID: uuid.New(), AuthorizationID: ptrUUID(uuid.New())}
 		doc, err := svc.CompleteUpload(context.Background(), su, input, []string{model.OfficeExtToMIME[".pptx"]}, 0)
 		if !errors.Is(err, ErrUnsupportedMediaType) {
 			t.Fatalf("err = %v, want ErrUnsupportedMediaType (allow-list rejects unrecovered zip)", err)
@@ -281,7 +281,7 @@ func TestCompleteUpload_TranscodePathMIMEUnaffected(t *testing.T) {
 	su.DetectedMIME = "application/zip"
 	su.MimeType = "image/jpeg"
 
-	input := model.CreateDocumentInput{DisplayName: "photo.jpg", StorageBucketID: uuid.New(), AuthorizationID: uuid.New()}
+	input := model.CreateDocumentInput{DisplayName: "photo.jpg", StorageBucketID: uuid.New(), AuthorizationID: ptrUUID(uuid.New())}
 	doc, err := svc.CompleteUpload(context.Background(), su, input, []string{"application/zip"}, 0)
 	if err != nil {
 		t.Fatalf("CompleteUpload: %v", err)

--- a/internal/domain/service/file_service.go
+++ b/internal/domain/service/file_service.go
@@ -99,6 +99,55 @@ func (s *FileService) ServeFile(ctx context.Context, documentID uuid.UUID, actor
 	}, nil
 }
 
+// BatchContentResult is one entry of a ReadContentBatch response, positionally
+// aligned with the requested id slice. Found reports whether the document's
+// content was retrieved: when true, Content + MimeType are populated; when
+// false, Err records the per-id reason (row missing, blob gone) without
+// failing the whole batch.
+type BatchContentResult struct {
+	ID       uuid.UUID
+	Found    bool
+	Content  []byte
+	MimeType string
+	Err      error
+}
+
+// ReadContentBatch resolves the content blob for each requested document id in
+// one call, preserving order (result[i] corresponds to ids[i], duplicates
+// included). It reuses the single-document read path — GetByID then
+// Storage.Read — per id, mirroring the internal /internal/file/{id}/content
+// endpoint, and applies no per-file authorization (these are internal,
+// NULL-authz snapshot blobs governed by the owning document's authorization).
+//
+// Failures are per-id and non-fatal: a missing row or a missing blob yields
+// Found=false with Err set for that position; the remaining ids still resolve.
+// This is what lets the server's derived-text resolvers fan a list of snapshot
+// pointers into a single request without an N+1 of HTTP round trips, and treat
+// individual misses as best-effort.
+func (s *FileService) ReadContentBatch(ctx context.Context, ids []uuid.UUID) []BatchContentResult {
+	results := make([]BatchContentResult, 0, len(ids))
+	for _, id := range ids {
+		results = append(results, s.readOneContent(ctx, id))
+	}
+	return results
+}
+
+// readOneContent resolves a single document's content for the batch read,
+// translating a missing row or unreadable blob into a non-fatal result rather
+// than an error return. Kept separate from GetContent's HTTP handler so the
+// domain owns the lookup-then-read sequence once.
+func (s *FileService) readOneContent(ctx context.Context, id uuid.UUID) BatchContentResult {
+	doc, err := s.Repo.GetByID(ctx, id)
+	if err != nil {
+		return BatchContentResult{ID: id, Found: false, Err: err}
+	}
+	content, err := s.Storage.Read(doc.ExternalID)
+	if err != nil {
+		return BatchContentResult{ID: id, Found: false, Err: fmt.Errorf("read file: %w", err)}
+	}
+	return BatchContentResult{ID: id, Found: true, Content: content, MimeType: doc.MimeType}
+}
+
 // CreateDocument ingests a complete buffer through the streaming pipeline
 // (spec 020): stage → validate → publish. Kept for buffer-shaped callers;
 // the HTTP handler streams the request directly via StageUpload +

--- a/internal/domain/service/file_service.go
+++ b/internal/domain/service/file_service.go
@@ -176,7 +176,7 @@ func (s *FileService) CopyDocument(ctx context.Context, sourceID uuid.UUID, inpu
 		CreatedBy:         input.CreatedBy,
 		TemporaryLocation: false,
 		StorageBucketID:   input.DestinationBucketID,
-		AuthorizationID:   input.AuthorizationID,
+		AuthorizationID:   &input.AuthorizationID,
 		TagsetID:          input.TagsetID,
 		SkipDedup:         input.SkipDedup,
 	}
@@ -281,7 +281,7 @@ func (s *FileService) insertDocument(ctx context.Context, input model.CreateDocu
 		CreatedBy:         input.CreatedBy,
 		TemporaryLocation: input.TemporaryLocation,
 		StorageBucketID:   input.StorageBucketID,
-		AuthorizationID:   input.AuthorizationID,
+		AuthorizationID:   derefUUID(input.AuthorizationID),
 		TagsetID:          input.TagsetID,
 		CreatedDate:       now,
 		UpdatedDate:       now,
@@ -303,13 +303,28 @@ func (s *FileService) insertDocument(ctx context.Context, input model.CreateDocu
 		if input.SkipDedup {
 			return nil, ErrConflict
 		}
-		// Default path: another concurrent creator won the race on the
-		// unique(externalID, storageBucketID) index. Re-query and return the
-		// winner with Reused=true.
+		// A unique violation here is one of two things, and the constraint name
+		// is schema-dependent (TypeORM emits opaque REL_* hashes; the standalone
+		// schema emits file_*_key), so we cannot reliably classify by name.
+		// Instead we probe by intent: the ONLY violation we can recover from is
+		// the per-bucket content-dedup race on (externalID, storageBucketID) —
+		// re-query that scope and, if a winner exists, return it as a dedup hit.
 		raced, findErr := s.reQueryRaceWinner(ctx, stored.ExternalID, input.StorageBucketID)
 		if findErr == nil {
 			raced.Reused = true
 			return &raced, nil
+		}
+		// No (externalID, bucket) winner ever materialized. This was therefore
+		// NOT the content-dedup race — it was a UNIQUE(authorizationId) or
+		// UNIQUE(tagsetId) violation: the caller supplied an id already held by
+		// another row (e.g. a snapshot reusing one fixed authorizationId). That
+		// is a client conflict (409), not a server fault: surface ErrConflict
+		// instead of 500-ing as a phantom dedup-race re-query failure.
+		if errors.Is(findErr, model.ErrDocumentNotFound) {
+			s.Logger.Warn("create: unique violation with no (externalID, bucket) winner — "+
+				"authorizationId/tagsetId already in use by another row",
+				zap.String("externalID", stored.ExternalID))
+			return nil, ErrConflict
 		}
 		s.Logger.Warn("dedup: unique violation but re-query failed",
 			zap.String("externalID", stored.ExternalID), zap.Error(findErr))
@@ -589,6 +604,17 @@ var (
 // normalizeMIME strips parameters and lowercases a MIME type.
 func normalizeMIME(mimeType string) string {
 	return model.NormalizeMIME(mimeType)
+}
+
+// derefUUID returns the pointed-to UUID, or uuid.Nil when the pointer is nil.
+// The adapter maps uuid.Nil to a NULL authorizationId column, so an optional
+// (nil) authz persists as NULL — which UNIQUE(authorizationId) permits any
+// number of (unlike a reused fixed id, which collides after the first row).
+func derefUUID(p *uuid.UUID) uuid.UUID {
+	if p == nil {
+		return uuid.Nil
+	}
+	return *p
 }
 
 // BackfillIfNeeded is the public entry point for handlers that read a

--- a/internal/domain/service/file_service.go
+++ b/internal/domain/service/file_service.go
@@ -58,6 +58,11 @@ type FileService struct {
 	Storage   port.StoragePort
 	Processor port.ImageProcessor
 	Logger    *zap.Logger
+
+	// sleep is the backoff hook for the dedup-race winner re-query. nil means
+	// time.Sleep (production); tests inject a no-op to run instantly. Optional
+	// so existing struct-literal constructions stay valid.
+	sleep func(time.Duration)
 }
 
 // ServeResult contains file content and metadata for serving.
@@ -299,9 +304,9 @@ func (s *FileService) insertDocument(ctx context.Context, input model.CreateDocu
 			return nil, ErrConflict
 		}
 		// Default path: another concurrent creator won the race on the
-		// unique(externalID, storageBucketID) index. Re-query and return
-		// the winner with Reused=true.
-		raced, findErr := s.Repo.FindByExternalIDAndBucket(ctx, stored.ExternalID, input.StorageBucketID)
+		// unique(externalID, storageBucketID) index. Re-query and return the
+		// winner with Reused=true.
+		raced, findErr := s.reQueryRaceWinner(ctx, stored.ExternalID, input.StorageBucketID)
 		if findErr == nil {
 			raced.Reused = true
 			return &raced, nil
@@ -311,6 +316,73 @@ func (s *FileService) insertDocument(ctx context.Context, input model.CreateDocu
 		return nil, fmt.Errorf("create document record: duplicate key, winner lookup failed: %w", findErr)
 	}
 	return nil, fmt.Errorf("create document record: %w", err)
+}
+
+// dedupReQueryAttempts and dedupReQueryBaseBackoff bound the winner re-query
+// after a unique-violation. The insert and the re-query use the same
+// (externalID, storageBucketID) scope and run as separate autocommit
+// statements on a pooled connection (no enclosing transaction), so the winning
+// INSERT is occasionally not yet visible to the loser's connection the instant
+// the violation fires — visibility settles a few milliseconds later. A single
+// re-query then spuriously returns ErrDocumentNotFound and the request 500s
+// ("dedup: unique violation but re-query failed … document not found").
+// Re-querying a few times with a short capped backoff turns that lost race
+// back into a successful dedup. Values are intentionally small: the contention
+// window is sub-millisecond and we must not stall the request thread.
+const (
+	dedupReQueryAttempts    = 5
+	dedupReQueryBaseBackoff = 2 * time.Millisecond
+	dedupReQueryMaxBackoff  = 20 * time.Millisecond
+)
+
+// reQueryRaceWinner re-reads the dedup winner after a unique-violation,
+// retrying with a short bounded backoff while the lookup still reports
+// ErrDocumentNotFound — the commit-visibility window. Any other lookup error
+// (or a hit) returns immediately; ErrDocumentNotFound is only returned after
+// the attempts are exhausted, so the caller can still surface a clear failure
+// if the winner genuinely never materializes.
+func (s *FileService) reQueryRaceWinner(ctx context.Context, externalID string, bucketID uuid.UUID) (model.Document, error) {
+	backoff := dedupReQueryBaseBackoff
+	var lastErr error
+	for attempt := 0; attempt < dedupReQueryAttempts; attempt++ {
+		if attempt > 0 {
+			if err := s.dedupBackoff(ctx, backoff); err != nil {
+				return model.Document{}, err
+			}
+			if backoff *= 2; backoff > dedupReQueryMaxBackoff {
+				backoff = dedupReQueryMaxBackoff
+			}
+		}
+		doc, err := s.Repo.FindByExternalIDAndBucket(ctx, externalID, bucketID)
+		if err == nil {
+			return doc, nil
+		}
+		if !errors.Is(err, model.ErrDocumentNotFound) {
+			// A real lookup failure (transport/DB) — don't mask it as a
+			// visibility lag; fail fast.
+			return model.Document{}, err
+		}
+		lastErr = err
+	}
+	return model.Document{}, lastErr
+}
+
+// dedupBackoff sleeps for d, honoring context cancellation so a client that
+// hangs up doesn't pin the request thread through the retry loop. Uses the
+// injected sleep hook when set (tests), else a ctx-aware timer.
+func (s *FileService) dedupBackoff(ctx context.Context, d time.Duration) error {
+	if s.sleep != nil {
+		s.sleep(d)
+		return ctx.Err()
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 // DeleteDocument removes a document record and its file (if not shared).

--- a/internal/domain/service/file_service_test.go
+++ b/internal/domain/service/file_service_test.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"errors"
 	"io"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"go.uber.org/zap"
@@ -416,6 +418,185 @@ func TestCreateDocument_Dedup_CreateRace_ReturnsWinnerAsReused(t *testing.T) {
 	}
 }
 
+// Commit-visibility race: two requests upload identical content concurrently.
+// The loser's Create hits the unique violation (ErrDuplicateKey), but the
+// winner's INSERT is not yet visible on the loser's pooled connection, so the
+// first winner re-query returns ErrDocumentNotFound. The dedup recovery must
+// retry the re-query (bounded backoff) until the winner becomes visible and
+// return it as Reused — never surface a 500. Regression test for the
+// "dedup: unique violation but re-query failed … document not found" 500s
+// observed in the unified-collab empty-memo e2e (two collab clients snapshot
+// identical bytes → identical hash → same-bucket collision).
+func TestCreateDocument_Dedup_CreateRace_WinnerNotYetVisible_RetriesThenReturnsWinner(t *testing.T) {
+	winnerID := uuid.New()
+	winnerAuth := uuid.New()
+	bucket := uuid.New()
+
+	// find call #1 (pre-Create dedup check): no row → fall through to Create.
+	// find calls #2..#N (post-violation re-query): winner invisible for the
+	// first few attempts (visibility lag across pooled connections), then
+	// becomes visible. The fix must keep retrying past the not-found window.
+	const invisibleReQueries = 2 // re-query attempts that still see "not found"
+	callCount := 0
+	repo := &mockRepoRace{
+		find: func() (model.Document, error) {
+			callCount++
+			if callCount == 1 {
+				return model.Document{}, model.ErrDocumentNotFound
+			}
+			if callCount <= 1+invisibleReQueries {
+				// Winner committed but not yet visible to this connection.
+				return model.Document{}, model.ErrDocumentNotFound
+			}
+			return model.Document{
+				ID:              winnerID,
+				ExternalID:      "sha3-of-content",
+				StorageBucketID: bucket,
+				AuthorizationID: winnerAuth,
+			}, nil
+		},
+		createErr: model.ErrDuplicateKey,
+	}
+	svc := &FileService{Logger: nopLogger, Repo: repo, Storage: &mockStorage{}, Processor: &mockProcessor{}}
+	svc.sleep = func(time.Duration) {} // no real backoff sleeps in tests
+
+	input := model.CreateDocumentInput{
+		DisplayName:     "empty-memo.txt",
+		StorageBucketID: bucket,
+		AuthorizationID: uuid.New(),
+	}
+	doc, err := svc.CreateDocument(context.Background(), input, []byte("content"), "", nil, 0)
+	if err != nil {
+		t.Fatalf("dedup must recover from the visibility window, got 500-class error: %v", err)
+	}
+	if !doc.Reused {
+		t.Error("expected Reused=true after losing the create race")
+	}
+	if doc.ID != winnerID {
+		t.Errorf("ID = %v, want winner %v", doc.ID, winnerID)
+	}
+	if doc.AuthorizationID != winnerAuth {
+		t.Errorf("AuthorizationID = %v, want winner %v", doc.AuthorizationID, winnerAuth)
+	}
+	// Pre-create check (1) + the invisible re-queries + the successful one.
+	wantMinFinds := 1 + invisibleReQueries + 1
+	if repo.findCalls < wantMinFinds {
+		t.Errorf("expected the winner re-query to be retried past the not-found window: findCalls = %d, want >= %d", repo.findCalls, wantMinFinds)
+	}
+}
+
+// Terminal case: Create hit ErrDuplicateKey but the winner is never visible
+// (genuinely missing row — e.g. winner rolled back, or visibility never
+// settles). The recovery must exhaust its bounded retries and then surface a
+// wrapped error rather than spin forever. The pre-create check is one find;
+// the re-query is then attempted multiple times.
+func TestCreateDocument_Dedup_CreateRace_WinnerNeverVisible_ExhaustsRetriesAndErrors(t *testing.T) {
+	bucket := uuid.New()
+	callCount := 0
+	repo := &mockRepoRace{
+		find: func() (model.Document, error) {
+			callCount++
+			// Always "not found": first call is the pre-create check, the rest
+			// are the re-query that never resolves.
+			return model.Document{}, model.ErrDocumentNotFound
+		},
+		createErr: model.ErrDuplicateKey,
+	}
+	svc := &FileService{Logger: nopLogger, Repo: repo, Storage: &mockStorage{}, Processor: &mockProcessor{}}
+	svc.sleep = func(time.Duration) {}
+
+	input := model.CreateDocumentInput{
+		DisplayName:     "test.txt",
+		StorageBucketID: bucket,
+		AuthorizationID: uuid.New(),
+	}
+	_, err := svc.CreateDocument(context.Background(), input, []byte("content"), "", nil, 0)
+	if err == nil {
+		t.Fatal("expected an error when the race winner never becomes visible")
+	}
+	// Must have retried the re-query (more than the single pre-create find).
+	if repo.findCalls < 3 {
+		t.Errorf("expected the re-query to be retried before giving up: findCalls = %d, want >= 3", repo.findCalls)
+	}
+}
+
+// A real lookup failure (transport/DB) during the post-violation re-query
+// must NOT be retried as if it were a visibility lag: it fails fast and the
+// error is surfaced. Guards against the bounded retry masking genuine DB
+// outages.
+func TestCreateDocument_Dedup_CreateRace_ReQueryTransportError_FailsFast(t *testing.T) {
+	bucket := uuid.New()
+	transportErr := errors.New("connection reset by peer")
+	callCount := 0
+	repo := &mockRepoRace{
+		find: func() (model.Document, error) {
+			callCount++
+			if callCount == 1 {
+				return model.Document{}, model.ErrDocumentNotFound // pre-create check
+			}
+			return model.Document{}, transportErr // re-query: real DB failure
+		},
+		createErr: model.ErrDuplicateKey,
+	}
+	svc := &FileService{Logger: nopLogger, Repo: repo, Storage: &mockStorage{}, Processor: &mockProcessor{}}
+	svc.sleep = func(time.Duration) {}
+
+	input := model.CreateDocumentInput{
+		DisplayName:     "test.txt",
+		StorageBucketID: bucket,
+		AuthorizationID: uuid.New(),
+	}
+	_, err := svc.CreateDocument(context.Background(), input, []byte("content"), "", nil, 0)
+	if err == nil {
+		t.Fatal("expected the transport error to surface")
+	}
+	if !errors.Is(err, transportErr) {
+		t.Errorf("expected wrapped transport error, got %v", err)
+	}
+	// Pre-create check (1) + exactly one re-query that fails fast (2). No retry.
+	if repo.findCalls != 2 {
+		t.Errorf("a real lookup failure must not be retried: findCalls = %d, want 2", repo.findCalls)
+	}
+}
+
+// A context cancelled during the dedup backoff window aborts the re-query loop
+// promptly rather than pinning the request thread for the full retry budget.
+// Exercises the production ctx-aware timer path (no injected sleep hook).
+func TestCreateDocument_Dedup_CreateRace_ContextCancelledDuringBackoff(t *testing.T) {
+	bucket := uuid.New()
+	callCount := 0
+	repo := &mockRepoRace{
+		find: func() (model.Document, error) {
+			callCount++
+			// Always not-found so the loop enters the backoff between attempts.
+			return model.Document{}, model.ErrDocumentNotFound
+		},
+		createErr: model.ErrDuplicateKey,
+	}
+	// No svc.sleep injected → real ctx-aware timer is used.
+	svc := &FileService{Logger: nopLogger, Repo: repo, Storage: &mockStorage{}, Processor: &mockProcessor{}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel almost immediately so the first inter-attempt backoff observes it.
+	go func() {
+		time.Sleep(1 * time.Millisecond)
+		cancel()
+	}()
+
+	input := model.CreateDocumentInput{
+		DisplayName:     "test.txt",
+		StorageBucketID: bucket,
+		AuthorizationID: uuid.New(),
+	}
+	_, err := svc.CreateDocument(ctx, input, []byte("content"), "", nil, 0)
+	if err == nil {
+		t.Fatal("expected an error after context cancellation")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled to propagate, got %v", err)
+	}
+}
+
 // SkipDedup: true → fresh row inserted even when an existing row matches.
 // Lookup must NOT be called; existing row must NOT be returned/mutated.
 func TestCreateDocument_SkipDedup_InsertsFreshRowWhenContentExists(t *testing.T) {
@@ -558,6 +739,7 @@ func TestCreateDocument_SkipDedup_DuplicateKey_ReturnsConflict(t *testing.T) {
 type mockRepoRace struct {
 	find      func() (model.Document, error)
 	createErr error
+	findCalls int
 }
 
 var _ port.DocumentRepo = (*mockRepoRace)(nil)
@@ -566,6 +748,7 @@ func (m *mockRepoRace) GetByID(_ context.Context, _ uuid.UUID) (model.Document, 
 	return model.Document{}, nil
 }
 func (m *mockRepoRace) FindByExternalIDAndBucket(_ context.Context, _ string, _ uuid.UUID) (model.Document, error) {
+	m.findCalls++
 	return m.find()
 }
 func (m *mockRepoRace) Create(_ context.Context, _ model.Document, _ model.ContentMetadata) (uuid.UUID, error) {
@@ -1784,4 +1967,170 @@ func (m *mockProcessor) TranscodeStream(r io.Reader, w io.Writer, mimeType strin
 
 func (m *dedupMockStorage) OpenStage(_ context.Context) (port.StageWriter, error) {
 	return nil, errors.New("dedupMockStorage: OpenStage not used in these tests")
+}
+
+// concurrentDedupRepo is a thread-safe, stateful DocumentRepo that faithfully
+// simulates the production database for the dedup race: Create enforces a
+// unique(externalID, storageBucketID) index (first writer wins, the rest get
+// ErrDuplicateKey), and FindByExternalIDAndBucket reflects committed rows —
+// but only after a configurable visibility delay, modelling the brief window
+// where a winning INSERT on one pooled connection is not yet visible to a
+// loser re-querying on another. Used by the end-to-end concurrency regression
+// test. -race clean.
+type concurrentDedupRepo struct {
+	mu sync.Mutex
+	// rows keyed by (externalID, bucket) — the unique index.
+	rows map[string]model.Document
+	// committedAt records when each key became visible to re-queries.
+	committedAt map[string]time.Time
+	// visibilityLag delays when a freshly-inserted row is observable by
+	// FindByExternalIDAndBucket (the commit-visibility window).
+	visibilityLag time.Duration
+	now           func() time.Time
+}
+
+var _ port.DocumentRepo = (*concurrentDedupRepo)(nil)
+
+func newConcurrentDedupRepo(lag time.Duration) *concurrentDedupRepo {
+	return &concurrentDedupRepo{
+		rows:          map[string]model.Document{},
+		committedAt:   map[string]time.Time{},
+		visibilityLag: lag,
+		now:           time.Now,
+	}
+}
+
+func dedupKey(externalID string, bucket uuid.UUID) string {
+	return externalID + "|" + bucket.String()
+}
+
+func (m *concurrentDedupRepo) Create(_ context.Context, doc model.Document, _ model.ContentMetadata) (uuid.UUID, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	k := dedupKey(doc.ExternalID, doc.StorageBucketID)
+	if _, exists := m.rows[k]; exists {
+		// Unique index violation — another writer already holds this content
+		// in this bucket.
+		return uuid.Nil, model.ErrDuplicateKey
+	}
+	m.rows[k] = doc
+	m.committedAt[k] = m.now().Add(m.visibilityLag)
+	return doc.ID, nil
+}
+
+func (m *concurrentDedupRepo) FindByExternalIDAndBucket(_ context.Context, externalID string, bucket uuid.UUID) (model.Document, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	k := dedupKey(externalID, bucket)
+	doc, exists := m.rows[k]
+	if !exists {
+		return model.Document{}, model.ErrDocumentNotFound
+	}
+	if m.now().Before(m.committedAt[k]) {
+		// Row exists but is not yet visible on this connection.
+		return model.Document{}, model.ErrDocumentNotFound
+	}
+	return doc, nil
+}
+
+func (m *concurrentDedupRepo) GetByID(_ context.Context, _ uuid.UUID) (model.Document, error) {
+	return model.Document{}, model.ErrDocumentNotFound
+}
+func (m *concurrentDedupRepo) UpdateFile(_ context.Context, _ uuid.UUID, _, _ string, _ int, _ model.ContentMetadata) error {
+	return nil
+}
+func (m *concurrentDedupRepo) UpdateMetadata(_ context.Context, _ uuid.UUID, _ uuid.UUID, _ bool, _ string, _ int) error {
+	return nil
+}
+func (m *concurrentDedupRepo) BackfillContentMetadata(_ context.Context, _ uuid.UUID, _ string, _ model.ContentMetadata) error {
+	return nil
+}
+func (m *concurrentDedupRepo) Delete(_ context.Context, _ uuid.UUID) (model.DeletedDocument, error) {
+	return model.DeletedDocument{}, nil
+}
+func (m *concurrentDedupRepo) CountByExternalID(_ context.Context, _ string) (int, error) {
+	return 0, nil
+}
+func (m *concurrentDedupRepo) ListByMimeTypes(_ context.Context, _ []string) ([]model.Document, error) {
+	return nil, nil
+}
+func (m *concurrentDedupRepo) UpdateMimeType(_ context.Context, _ uuid.UUID, _, _ string) (bool, error) {
+	return true, nil
+}
+
+// TestCreateDocument_ConcurrentIdenticalContent_BothDedupNo500 is the
+// end-to-end regression test for the dedup upsert race surfaced by the
+// unified-collab empty-memo e2e: two requests upload byte-identical content
+// (same content-hash externalID) into the same bucket at the same time. With a
+// commit-visibility lag in play, exactly one INSERT wins; the loser must
+// recover the winner via the bounded re-query and return it as a dedup hit.
+// Both requests must succeed, return the SAME document id, and produce ZERO
+// 500-class errors. Run under -race.
+func TestCreateDocument_ConcurrentIdenticalContent_BothDedupNo500(t *testing.T) {
+	bucket := uuid.New()
+	// Visibility lag longer than the first backoff so the loser's first
+	// re-query reliably misses and must retry — the exact failure mode.
+	repo := newConcurrentDedupRepo(5 * time.Millisecond)
+
+	content := []byte("") // empty memo snapshot: identical bytes, identical hash
+	const goroutines = 8
+
+	type result struct {
+		doc *model.Document
+		err error
+	}
+	results := make([]result, goroutines)
+
+	var start sync.WaitGroup
+	start.Add(1)
+	var done sync.WaitGroup
+	done.Add(goroutines)
+
+	for i := 0; i < goroutines; i++ {
+		go func(idx int) {
+			defer done.Done()
+			// Each goroutine gets its own storage/processor (one writer per
+			// instance) so only the shared repo exercises concurrency.
+			svc := &FileService{
+				Logger:    nopLogger,
+				Repo:      repo,
+				Storage:   &mockStorage{},
+				Processor: &mockProcessor{},
+			}
+			input := model.CreateDocumentInput{
+				DisplayName:     "empty-memo.txt",
+				StorageBucketID: bucket,
+				AuthorizationID: uuid.New(),
+			}
+			start.Wait() // release all goroutines together
+			doc, err := svc.CreateDocument(context.Background(), input, content, "", nil, 0)
+			results[idx] = result{doc: doc, err: err}
+		}(i)
+	}
+
+	start.Done()
+	done.Wait()
+
+	var winnerID uuid.UUID
+	reusedCount := 0
+	for i, r := range results {
+		if r.err != nil {
+			t.Fatalf("goroutine %d: identical-content upload must dedup, got error (500): %v", i, r.err)
+		}
+		if r.doc == nil {
+			t.Fatalf("goroutine %d: nil document with no error", i)
+		}
+		if winnerID == uuid.Nil {
+			winnerID = r.doc.ID
+		} else if r.doc.ID != winnerID {
+			t.Errorf("goroutine %d: doc ID = %v, want the single winner %v (dedup must converge on one row)", i, r.doc.ID, winnerID)
+		}
+		if r.doc.Reused {
+			reusedCount++
+		}
+	}
+	// Exactly one inserter wins; every other request is a dedup hit (Reused).
+	if reusedCount != goroutines-1 {
+		t.Errorf("expected %d dedup hits (Reused=true), got %d", goroutines-1, reusedCount)
+	}
 }

--- a/internal/domain/service/file_service_test.go
+++ b/internal/domain/service/file_service_test.go
@@ -18,6 +18,10 @@ import (
 
 var nopLogger = zap.NewNop()
 
+// ptrUUID returns the address of u, for fields like
+// model.CreateDocumentInput.AuthorizationID which are *uuid.UUID.
+func ptrUUID(u uuid.UUID) *uuid.UUID { return &u }
+
 // --- Mocks ---
 
 type mockRepo struct {
@@ -40,6 +44,11 @@ type mockRepo struct {
 	// Captured args from Create / UpdateFile content_metadata params.
 	lastCreateContentMetadata     model.ContentMetadata
 	lastUpdateFileContentMetadata model.ContentMetadata
+
+	// lastCreateDoc captures the full document passed to Create so tests can
+	// assert how the service maps input fields (e.g. a nil AuthorizationID
+	// must reach the repo as uuid.Nil → NULL authz column).
+	lastCreateDoc model.Document
 
 	// Replace-path capture (spec 019): persisted MIME and call count.
 	updateFileCalls    int
@@ -83,6 +92,7 @@ func (m *mockRepo) FindByExternalIDAndBucket(_ context.Context, externalID strin
 func (m *mockRepo) Create(_ context.Context, doc model.Document, contentMetadata model.ContentMetadata) (uuid.UUID, error) {
 	m.createCalls++
 	m.lastCreateContentMetadata = contentMetadata
+	m.lastCreateDoc = doc
 	if m.createErrOnce != nil && m.createCalls == 1 {
 		return uuid.Nil, m.createErrOnce
 	}
@@ -273,7 +283,7 @@ func TestCreateDocument_Happy(t *testing.T) {
 	input := model.CreateDocumentInput{
 		DisplayName:     "test.txt",
 		StorageBucketID: uuid.New(),
-		AuthorizationID: uuid.New(),
+		AuthorizationID: ptrUUID(uuid.New()),
 	}
 
 	doc, err := svc.CreateDocument(context.Background(), input, []byte("content"), "", nil, 0)
@@ -288,6 +298,37 @@ func TestCreateDocument_Happy(t *testing.T) {
 	}
 	if doc.Reused {
 		t.Error("expected Reused=false for new content")
+	}
+}
+
+// A nil AuthorizationID (an internal caller — e.g. the collaboration snapshot
+// store — that omits authz so the row's authz column is NULL) must reach the
+// repository as uuid.Nil, which the adapter maps to a NULL column. UNIQUE on
+// authorizationId then permits any number of such rows, so many snapshots can
+// coexist in one bucket.
+func TestCreateDocument_NilAuthorization_PersistsAsNil(t *testing.T) {
+	repo := &mockRepo{}
+	svc := &FileService{Logger: nopLogger,
+		Repo:      repo,
+		Storage:   &mockStorage{},
+		Processor: &mockProcessor{},
+	}
+
+	input := model.CreateDocumentInput{
+		DisplayName:     "snapshot.ybin",
+		StorageBucketID: uuid.New(),
+		AuthorizationID: nil, // internal snapshot blob → NULL authz
+	}
+
+	doc, err := svc.CreateDocument(context.Background(), input, []byte("content"), "", nil, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if doc.Reused {
+		t.Error("expected Reused=false for new content")
+	}
+	if repo.lastCreateDoc.AuthorizationID != uuid.Nil {
+		t.Errorf("persisted AuthorizationID = %v, want uuid.Nil (→ NULL column)", repo.lastCreateDoc.AuthorizationID)
 	}
 }
 
@@ -318,7 +359,7 @@ func TestCreateDocument_Dedup_SameContentSameBucket_ReturnsExisting(t *testing.T
 	input := model.CreateDocumentInput{
 		DisplayName:     "test.txt",
 		StorageBucketID: bucket,
-		AuthorizationID: callerAuth,
+		AuthorizationID: ptrUUID(callerAuth),
 		TagsetID:        &callerTagset,
 	}
 
@@ -355,7 +396,7 @@ func TestCreateDocument_Dedup_SameContentDifferentBucket_InsertsNew(t *testing.T
 	input := model.CreateDocumentInput{
 		DisplayName:     "test.txt",
 		StorageBucketID: uuid.New(),
-		AuthorizationID: uuid.New(),
+		AuthorizationID: ptrUUID(uuid.New()),
 	}
 	doc, err := svc.CreateDocument(context.Background(), input, []byte("content"), "", nil, 0)
 	if err != nil {
@@ -401,7 +442,7 @@ func TestCreateDocument_Dedup_CreateRace_ReturnsWinnerAsReused(t *testing.T) {
 	input := model.CreateDocumentInput{
 		DisplayName:     "test.txt",
 		StorageBucketID: bucket,
-		AuthorizationID: uuid.New(),
+		AuthorizationID: ptrUUID(uuid.New()),
 	}
 	doc, err := svc.CreateDocument(context.Background(), input, []byte("content"), "", nil, 0)
 	if err != nil {
@@ -463,7 +504,7 @@ func TestCreateDocument_Dedup_CreateRace_WinnerNotYetVisible_RetriesThenReturnsW
 	input := model.CreateDocumentInput{
 		DisplayName:     "empty-memo.txt",
 		StorageBucketID: bucket,
-		AuthorizationID: uuid.New(),
+		AuthorizationID: ptrUUID(uuid.New()),
 	}
 	doc, err := svc.CreateDocument(context.Background(), input, []byte("content"), "", nil, 0)
 	if err != nil {
@@ -485,12 +526,13 @@ func TestCreateDocument_Dedup_CreateRace_WinnerNotYetVisible_RetriesThenReturnsW
 	}
 }
 
-// Terminal case: Create hit ErrDuplicateKey but the winner is never visible
-// (genuinely missing row — e.g. winner rolled back, or visibility never
-// settles). The recovery must exhaust its bounded retries and then surface a
-// wrapped error rather than spin forever. The pre-create check is one find;
-// the re-query is then attempted multiple times.
-func TestCreateDocument_Dedup_CreateRace_WinnerNeverVisible_ExhaustsRetriesAndErrors(t *testing.T) {
+// Terminal case: Create hit ErrDuplicateKey but no (externalID, bucket) winner
+// ever materializes. After exhausting its bounded retries the service concludes
+// this was NOT the content-dedup race but a UNIQUE(authorizationId)/
+// UNIQUE(tagsetId) collision — a client conflict — and surfaces ErrConflict
+// (409) rather than a phantom 500. The pre-create check is one find; the
+// re-query is then attempted multiple times before the classification fires.
+func TestCreateDocument_Dedup_CreateRace_WinnerNeverVisible_ClassifiesAsConflict(t *testing.T) {
 	bucket := uuid.New()
 	callCount := 0
 	repo := &mockRepoRace{
@@ -508,13 +550,14 @@ func TestCreateDocument_Dedup_CreateRace_WinnerNeverVisible_ExhaustsRetriesAndEr
 	input := model.CreateDocumentInput{
 		DisplayName:     "test.txt",
 		StorageBucketID: bucket,
-		AuthorizationID: uuid.New(),
+		AuthorizationID: ptrUUID(uuid.New()),
 	}
 	_, err := svc.CreateDocument(context.Background(), input, []byte("content"), "", nil, 0)
-	if err == nil {
-		t.Fatal("expected an error when the race winner never becomes visible")
+	if !errors.Is(err, ErrConflict) {
+		t.Fatalf("err = %v, want ErrConflict (authz/tagset collision, not a 500)", err)
 	}
-	// Must have retried the re-query (more than the single pre-create find).
+	// Must have retried the re-query (more than the single pre-create find)
+	// before classifying the violation.
 	if repo.findCalls < 3 {
 		t.Errorf("expected the re-query to be retried before giving up: findCalls = %d, want >= 3", repo.findCalls)
 	}
@@ -544,7 +587,7 @@ func TestCreateDocument_Dedup_CreateRace_ReQueryTransportError_FailsFast(t *test
 	input := model.CreateDocumentInput{
 		DisplayName:     "test.txt",
 		StorageBucketID: bucket,
-		AuthorizationID: uuid.New(),
+		AuthorizationID: ptrUUID(uuid.New()),
 	}
 	_, err := svc.CreateDocument(context.Background(), input, []byte("content"), "", nil, 0)
 	if err == nil {
@@ -586,7 +629,7 @@ func TestCreateDocument_Dedup_CreateRace_ContextCancelledDuringBackoff(t *testin
 	input := model.CreateDocumentInput{
 		DisplayName:     "test.txt",
 		StorageBucketID: bucket,
-		AuthorizationID: uuid.New(),
+		AuthorizationID: ptrUUID(uuid.New()),
 	}
 	_, err := svc.CreateDocument(ctx, input, []byte("content"), "", nil, 0)
 	if err == nil {
@@ -617,7 +660,7 @@ func TestCreateDocument_SkipDedup_InsertsFreshRowWhenContentExists(t *testing.T)
 	input := model.CreateDocumentInput{
 		DisplayName:     "placeholder.docx",
 		StorageBucketID: bucket,
-		AuthorizationID: callerAuth,
+		AuthorizationID: ptrUUID(callerAuth),
 		TagsetID:        &callerTagset,
 		SkipDedup:       true,
 	}
@@ -661,7 +704,7 @@ func TestCreateDocument_SkipDedup_EmptyContent_GetsFreshRow(t *testing.T) {
 	input := model.CreateDocumentInput{
 		DisplayName:     "doc.docx",
 		StorageBucketID: bucket,
-		AuthorizationID: uuid.New(),
+		AuthorizationID: ptrUUID(uuid.New()),
 		SkipDedup:       true,
 	}
 	doc, err := svc.CreateDocument(context.Background(), input, []byte{}, "application/vnd.openxmlformats-officedocument.wordprocessingml.document", []string{"application/vnd.openxmlformats-officedocument.wordprocessingml.document"}, 0)
@@ -694,7 +737,7 @@ func TestCreateDocument_SkipDedupOmitted_DedupStillApplies(t *testing.T) {
 	input := model.CreateDocumentInput{
 		DisplayName:     "test.txt",
 		StorageBucketID: bucket,
-		AuthorizationID: uuid.New(),
+		AuthorizationID: ptrUUID(uuid.New()),
 		// SkipDedup omitted → defaults to false
 	}
 	doc, err := svc.CreateDocument(context.Background(), input, []byte("content"), "", nil, 0)
@@ -725,7 +768,7 @@ func TestCreateDocument_SkipDedup_DuplicateKey_ReturnsConflict(t *testing.T) {
 	input := model.CreateDocumentInput{
 		DisplayName:     "test.docx",
 		StorageBucketID: uuid.New(),
-		AuthorizationID: uuid.New(),
+		AuthorizationID: ptrUUID(uuid.New()),
 		SkipDedup:       true,
 	}
 	_, err := svc.CreateDocument(context.Background(), input, []byte("content"), "", nil, 0)
@@ -783,7 +826,7 @@ func TestCreateDocument_TooLarge(t *testing.T) {
 		Processor: &mockProcessor{},
 	}
 
-	input := model.CreateDocumentInput{DisplayName: "big.bin", StorageBucketID: uuid.New(), AuthorizationID: uuid.New()}
+	input := model.CreateDocumentInput{DisplayName: "big.bin", StorageBucketID: uuid.New(), AuthorizationID: ptrUUID(uuid.New())}
 	_, err := svc.CreateDocument(context.Background(), input, []byte("content"), "", nil, 3)
 	if !errors.Is(err, ErrPayloadTooLarge) {
 		t.Errorf("expected ErrPayloadTooLarge, got %v", err)
@@ -797,7 +840,7 @@ func TestCreateDocument_UnsupportedMIME(t *testing.T) {
 		Processor: &mockProcessor{},
 	}
 
-	input := model.CreateDocumentInput{DisplayName: "test.bin", StorageBucketID: uuid.New(), AuthorizationID: uuid.New()}
+	input := model.CreateDocumentInput{DisplayName: "test.bin", StorageBucketID: uuid.New(), AuthorizationID: ptrUUID(uuid.New())}
 	_, err := svc.CreateDocument(context.Background(), input, []byte("content"), "", []string{"image/jpeg"}, 0)
 	if !errors.Is(err, ErrUnsupportedMediaType) {
 		t.Errorf("expected ErrUnsupportedMediaType, got %v", err)
@@ -811,7 +854,7 @@ func TestCreateDocument_EmptyContent_UsesDeclaredMIME(t *testing.T) {
 		Processor: &mockProcessor{},
 	}
 
-	input := model.CreateDocumentInput{DisplayName: "new.docx", StorageBucketID: uuid.New(), AuthorizationID: uuid.New()}
+	input := model.CreateDocumentInput{DisplayName: "new.docx", StorageBucketID: uuid.New(), AuthorizationID: ptrUUID(uuid.New())}
 	doc, err := svc.CreateDocument(context.Background(), input, []byte{}, "application/vnd.openxmlformats-officedocument.wordprocessingml.document", []string{"application/vnd.openxmlformats-officedocument.wordprocessingml.document"}, 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -828,7 +871,7 @@ func TestCreateDocument_EmptyContent_RejectsDisallowedMIME(t *testing.T) {
 		Processor: &mockProcessor{},
 	}
 
-	input := model.CreateDocumentInput{DisplayName: "bad.exe", StorageBucketID: uuid.New(), AuthorizationID: uuid.New()}
+	input := model.CreateDocumentInput{DisplayName: "bad.exe", StorageBucketID: uuid.New(), AuthorizationID: ptrUUID(uuid.New())}
 	_, err := svc.CreateDocument(context.Background(), input, []byte{}, "application/x-executable", []string{"image/png", "image/jpeg"}, 0)
 	if !errors.Is(err, ErrUnsupportedMediaType) {
 		t.Errorf("expected ErrUnsupportedMediaType, got %v", err)
@@ -848,7 +891,7 @@ func TestCreateDocument_DBFails_DoesNotDeleteBlob(t *testing.T) {
 		Processor: &mockProcessor{},
 	}
 
-	input := model.CreateDocumentInput{DisplayName: "test.txt", StorageBucketID: uuid.New(), AuthorizationID: uuid.New()}
+	input := model.CreateDocumentInput{DisplayName: "test.txt", StorageBucketID: uuid.New(), AuthorizationID: ptrUUID(uuid.New())}
 	_, err := svc.CreateDocument(context.Background(), input, []byte("content"), "", nil, 0)
 	if err == nil {
 		t.Fatal("expected error")
@@ -1295,7 +1338,7 @@ func TestCreateDocument_StorageFails(t *testing.T) {
 		Processor: &mockProcessor{},
 	}
 
-	input := model.CreateDocumentInput{DisplayName: "test.txt", StorageBucketID: uuid.New(), AuthorizationID: uuid.New()}
+	input := model.CreateDocumentInput{DisplayName: "test.txt", StorageBucketID: uuid.New(), AuthorizationID: ptrUUID(uuid.New())}
 	_, err := svc.CreateDocument(context.Background(), input, []byte("content"), "", nil, 0)
 	if err == nil {
 		t.Fatal("expected error for storage failure")
@@ -1335,7 +1378,7 @@ func TestCreateDocument_ProcessorFails(t *testing.T) {
 		Processor: &mockProcessor{processErr: errors.New("corrupt image"), detectMIME: "image/png"},
 	}
 
-	input := model.CreateDocumentInput{DisplayName: "bad.jpg", StorageBucketID: uuid.New(), AuthorizationID: uuid.New()}
+	input := model.CreateDocumentInput{DisplayName: "bad.jpg", StorageBucketID: uuid.New(), AuthorizationID: ptrUUID(uuid.New())}
 	_, err := svc.CreateDocument(context.Background(), input, []byte("content"), "", nil, 0)
 	if err == nil {
 		t.Fatal("expected error for processor failure")
@@ -1462,7 +1505,7 @@ func TestCreateDocument_DBFails_DedupDoesNotDeleteSharedBlob(t *testing.T) {
 		Processor: &mockProcessor{},
 	}
 
-	input := model.CreateDocumentInput{DisplayName: "test.txt", StorageBucketID: uuid.New(), AuthorizationID: uuid.New()}
+	input := model.CreateDocumentInput{DisplayName: "test.txt", StorageBucketID: uuid.New(), AuthorizationID: ptrUUID(uuid.New())}
 	_, err := svc.CreateDocument(context.Background(), input, []byte("content"), "", nil, 0)
 	if err == nil {
 		t.Fatal("expected error")
@@ -1533,7 +1576,7 @@ func TestCreateDocument_DedupHitOnLegacyImageRow_TriggersBackfill(t *testing.T) 
 	input := model.CreateDocumentInput{
 		DisplayName:     "img.jpg",
 		StorageBucketID: bucket,
-		AuthorizationID: uuid.New(),
+		AuthorizationID: ptrUUID(uuid.New()),
 	}
 	doc, err := svc.CreateDocument(context.Background(), input, []byte("content"), "", nil, 0)
 	if err != nil {
@@ -1579,7 +1622,7 @@ func TestCreateDocument_DedupHitOnNonImage_NoBackfill(t *testing.T) {
 	input := model.CreateDocumentInput{
 		DisplayName:     "doc.pdf",
 		StorageBucketID: bucket,
-		AuthorizationID: uuid.New(),
+		AuthorizationID: ptrUUID(uuid.New()),
 	}
 	_, err := svc.CreateDocument(context.Background(), input, []byte("content"), "", nil, 0)
 	if err != nil {
@@ -1611,7 +1654,7 @@ func TestCreateDocument_DedupHit_MeasureDimsFails_PersistsSentinel(t *testing.T)
 	input := model.CreateDocumentInput{
 		DisplayName:     "img.jpg",
 		StorageBucketID: bucket,
-		AuthorizationID: uuid.New(),
+		AuthorizationID: ptrUUID(uuid.New()),
 	}
 	doc, err := svc.CreateDocument(context.Background(), input, []byte("content"), "", nil, 0)
 	if err != nil {
@@ -1653,7 +1696,7 @@ func TestCreateDocument_DedupHit_NoDecoderAvailable_SkipsPersist(t *testing.T) {
 	input := model.CreateDocumentInput{
 		DisplayName:     "img.png",
 		StorageBucketID: bucket,
-		AuthorizationID: uuid.New(),
+		AuthorizationID: ptrUUID(uuid.New()),
 	}
 	doc, err := svc.CreateDocument(context.Background(), input, []byte("content"), "", nil, 0)
 	if err != nil {
@@ -1688,7 +1731,7 @@ func TestCreateDocument_DedupHit_StorageReadFails_GracefulDegrade(t *testing.T) 
 	input := model.CreateDocumentInput{
 		DisplayName:     "img.jpg",
 		StorageBucketID: bucket,
-		AuthorizationID: uuid.New(),
+		AuthorizationID: ptrUUID(uuid.New()),
 	}
 	doc, err := svc.CreateDocument(context.Background(), input, []byte("content"), "", nil, 0)
 	if err != nil {
@@ -1723,7 +1766,7 @@ func TestCreateDocument_DedupHit_PersistFails_ResponseStillCarriesDims(t *testin
 	input := model.CreateDocumentInput{
 		DisplayName:     "img.jpg",
 		StorageBucketID: bucket,
-		AuthorizationID: uuid.New(),
+		AuthorizationID: ptrUUID(uuid.New()),
 	}
 	doc, err := svc.CreateDocument(context.Background(), input, []byte("content"), "", nil, 0)
 	if err != nil {
@@ -1763,7 +1806,7 @@ func TestCreateDocument_DedupHit_AlreadyMeasured_SkipsBackfill(t *testing.T) {
 	input := model.CreateDocumentInput{
 		DisplayName:     "img.jpg",
 		StorageBucketID: bucket,
-		AuthorizationID: uuid.New(),
+		AuthorizationID: ptrUUID(uuid.New()),
 	}
 	doc, err := svc.CreateDocument(context.Background(), input, []byte("content"), "", nil, 0)
 	if err != nil {
@@ -1801,7 +1844,7 @@ func TestCreateDocument_DedupHit_DecodeFailedSentinel_SkipsBackfill(t *testing.T
 	input := model.CreateDocumentInput{
 		DisplayName:     "img.jpg",
 		StorageBucketID: bucket,
-		AuthorizationID: uuid.New(),
+		AuthorizationID: ptrUUID(uuid.New()),
 	}
 	doc, err := svc.CreateDocument(context.Background(), input, []byte("content"), "", nil, 0)
 	if err != nil {
@@ -2100,7 +2143,7 @@ func TestCreateDocument_ConcurrentIdenticalContent_BothDedupNo500(t *testing.T) 
 			input := model.CreateDocumentInput{
 				DisplayName:     "empty-memo.txt",
 				StorageBucketID: bucket,
-				AuthorizationID: uuid.New(),
+				AuthorizationID: ptrUUID(uuid.New()),
 			}
 			start.Wait() // release all goroutines together
 			doc, err := svc.CreateDocument(context.Background(), input, content, "", nil, 0)

--- a/internal/domain/service/file_service_test.go
+++ b/internal/domain/service/file_service_test.go
@@ -25,8 +25,16 @@ func ptrUUID(u uuid.UUID) *uuid.UUID { return &u }
 // --- Mocks ---
 
 type mockRepo struct {
-	doc           model.Document
-	getErr        error
+	doc    model.Document
+	getErr error
+
+	// docsByID, when non-nil, makes GetByID id-aware: it returns the mapped
+	// document for a known id and model.ErrDocumentNotFound for an unknown
+	// one. Used by the batched-read tests, which need several distinct rows in
+	// one call. When nil, GetByID falls back to the doc/getErr pair so existing
+	// single-document tests are unaffected.
+	docsByID map[uuid.UUID]model.Document
+
 	findDoc       *model.Document // nil means "not found"
 	findErr       error           // if set, overrides findDoc
 	findCalls     int
@@ -74,7 +82,13 @@ type mockRepo struct {
 // Ensure mockRepo implements the full interface at compile time.
 var _ port.DocumentRepo = (*mockRepo)(nil)
 
-func (m *mockRepo) GetByID(_ context.Context, _ uuid.UUID) (model.Document, error) {
+func (m *mockRepo) GetByID(_ context.Context, id uuid.UUID) (model.Document, error) {
+	if m.docsByID != nil {
+		if doc, ok := m.docsByID[id]; ok {
+			return doc, nil
+		}
+		return model.Document{}, model.ErrDocumentNotFound
+	}
 	return m.doc, m.getErr
 }
 func (m *mockRepo) FindByExternalIDAndBucket(_ context.Context, externalID string, storageBucketID uuid.UUID) (model.Document, error) {

--- a/internal/domain/service/ingest_test.go
+++ b/internal/domain/service/ingest_test.go
@@ -82,7 +82,7 @@ func TestStageUpload_PassThroughEquivalence(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	input := model.CreateDocumentInput{DisplayName: "f.bin", StorageBucketID: uuid.New(), AuthorizationID: uuid.New()}
+	input := model.CreateDocumentInput{DisplayName: "f.bin", StorageBucketID: uuid.New(), AuthorizationID: ptrUUID(uuid.New())}
 	doc, err := svc.CompleteUpload(context.Background(), su, input, nil, 0)
 	if err != nil {
 		t.Fatal(err)
@@ -131,7 +131,7 @@ func TestStageUpload_ClientAbortAborts(t *testing.T) {
 func TestCompleteUpload_TrailingPolicyViolationAborts(t *testing.T) {
 	storage := &mockStorage{}
 	svc := newIngestService(storage, &mockRepo{})
-	input := model.CreateDocumentInput{DisplayName: "f.bin", StorageBucketID: uuid.New(), AuthorizationID: uuid.New()}
+	input := model.CreateDocumentInput{DisplayName: "f.bin", StorageBucketID: uuid.New(), AuthorizationID: ptrUUID(uuid.New())}
 
 	su, err := svc.StageUpload(context.Background(), bytes.NewReader([]byte("plain text body")), "")
 	if err != nil {
@@ -160,7 +160,7 @@ func TestCompleteUpload_DedupAtEnd(t *testing.T) {
 	storage := &mockStorage{stageDedupHit: true}
 	repo := &mockRepo{findDoc: &existing}
 	svc := newIngestService(storage, repo)
-	input := model.CreateDocumentInput{DisplayName: "dup.bin", StorageBucketID: uuid.New(), AuthorizationID: uuid.New()}
+	input := model.CreateDocumentInput{DisplayName: "dup.bin", StorageBucketID: uuid.New(), AuthorizationID: ptrUUID(uuid.New())}
 
 	su, err := svc.StageUpload(context.Background(), bytes.NewReader([]byte("dup content")), "")
 	if err != nil {
@@ -253,7 +253,7 @@ func TestIngest_OutcomeLogging(t *testing.T) {
 			name: "accepted",
 			run: func(svc *FileService) {
 				su, _ := svc.StageUpload(context.Background(), bytes.NewReader([]byte("ok")), "")
-				input := model.CreateDocumentInput{DisplayName: "a", StorageBucketID: uuid.New(), AuthorizationID: uuid.New()}
+				input := model.CreateDocumentInput{DisplayName: "a", StorageBucketID: uuid.New(), AuthorizationID: ptrUUID(uuid.New())}
 				_, _ = svc.CompleteUpload(context.Background(), su, input, nil, 0)
 			},
 			wantMsg: "ingest accepted",

--- a/internal/domain/service/read_content_batch_test.go
+++ b/internal/domain/service/read_content_batch_test.go
@@ -1,0 +1,139 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/alkem-io/file-service/internal/domain/model"
+)
+
+func newBatchService(repo *mockRepo, storage *mockStorage) *FileService {
+	return &FileService{
+		Repo:      repo,
+		Auth:      &mockAuth{allowed: true},
+		Storage:   storage,
+		Processor: &mockProcessor{},
+		Logger:    nopLogger,
+	}
+}
+
+// ReadContentBatch returns one result per requested id, in request order, each
+// carrying the document's blob + MIME — reusing the same GetByID + Storage.Read
+// path as the single-document read. This is the reusable core the batched HTTP
+// endpoint sits on.
+func TestReadContentBatch_ReturnsEachBlobInOrder(t *testing.T) {
+	a, b := uuid.New(), uuid.New()
+	repo := &mockRepo{docsByID: map[uuid.UUID]model.Document{
+		a: {ID: a, ExternalID: "ext-a", MimeType: "text/plain"},
+		b: {ID: b, ExternalID: "ext-b", MimeType: "application/octet-stream"},
+	}}
+	storage := &mockStorage{dataByID: map[string][]byte{
+		"ext-a": []byte("AAA"),
+		"ext-b": []byte("BBB"),
+	}}
+	svc := newBatchService(repo, storage)
+
+	results := svc.ReadContentBatch(context.Background(), []uuid.UUID{a, b})
+
+	if len(results) != 2 {
+		t.Fatalf("len(results) = %d, want 2", len(results))
+	}
+	if results[0].ID != a || !results[0].Found || string(results[0].Content) != "AAA" || results[0].MimeType != "text/plain" {
+		t.Errorf("results[0] = %+v, want a/found/AAA/text-plain", results[0])
+	}
+	if results[1].ID != b || !results[1].Found || string(results[1].Content) != "BBB" || results[1].MimeType != "application/octet-stream" {
+		t.Errorf("results[1] = %+v, want b/found/BBB/octet-stream", results[1])
+	}
+}
+
+// A document id with no row is reported non-fatally (Found=false, Err set) and
+// does not abort the batch — the other ids still resolve.
+func TestReadContentBatch_UnknownDocumentNonFatal(t *testing.T) {
+	present, missing := uuid.New(), uuid.New()
+	repo := &mockRepo{docsByID: map[uuid.UUID]model.Document{
+		present: {ID: present, ExternalID: "ext", MimeType: "text/plain"},
+		// missing intentionally absent.
+	}}
+	storage := &mockStorage{dataByID: map[string][]byte{"ext": []byte("ok")}}
+	svc := newBatchService(repo, storage)
+
+	results := svc.ReadContentBatch(context.Background(), []uuid.UUID{present, missing})
+
+	if len(results) != 2 {
+		t.Fatalf("len(results) = %d, want 2", len(results))
+	}
+	if !results[0].Found {
+		t.Errorf("results[0] (present) Found = false, want true")
+	}
+	if results[1].Found {
+		t.Errorf("results[1] (missing) Found = true, want false")
+	}
+	if results[1].Err == nil {
+		t.Errorf("results[1] (missing) Err = nil, want non-fatal not-found error")
+	}
+	if !errors.Is(results[1].Err, model.ErrDocumentNotFound) {
+		t.Errorf("results[1].Err = %v, want wraps ErrDocumentNotFound", results[1].Err)
+	}
+}
+
+// A document whose blob is gone from storage is also a non-fatal miss: the row
+// resolves but Storage.Read fails, so Found=false with the read error recorded.
+func TestReadContentBatch_BlobReadErrorNonFatal(t *testing.T) {
+	id := uuid.New()
+	repo := &mockRepo{docsByID: map[uuid.UUID]model.Document{
+		id: {ID: id, ExternalID: "ext-gone", MimeType: "text/plain"},
+	}}
+	// dataByID is non-nil but doesn't contain "ext-gone" → Read returns readErr.
+	storage := &mockStorage{
+		dataByID: map[string][]byte{"other": []byte("x")},
+		readErr:  errors.New("blob not on storage"),
+	}
+	svc := newBatchService(repo, storage)
+
+	results := svc.ReadContentBatch(context.Background(), []uuid.UUID{id})
+
+	if len(results) != 1 {
+		t.Fatalf("len(results) = %d, want 1", len(results))
+	}
+	if results[0].Found {
+		t.Errorf("Found = true, want false on storage read error")
+	}
+	if results[0].Err == nil {
+		t.Errorf("Err = nil, want the storage read error recorded")
+	}
+}
+
+// An empty id slice yields an empty (non-nil) result slice — the service layer
+// imposes no minimum; the HTTP layer is where "empty request" becomes a 400.
+func TestReadContentBatch_EmptyInput(t *testing.T) {
+	svc := newBatchService(&mockRepo{}, &mockStorage{})
+	results := svc.ReadContentBatch(context.Background(), nil)
+	if len(results) != 0 {
+		t.Fatalf("len(results) = %d, want 0", len(results))
+	}
+}
+
+// Duplicate ids are each resolved positionally — the batch is a list, not a
+// set, so the caller's index-based fan-in stays aligned.
+func TestReadContentBatch_DuplicatesPreserved(t *testing.T) {
+	id := uuid.New()
+	repo := &mockRepo{docsByID: map[uuid.UUID]model.Document{
+		id: {ID: id, ExternalID: "ext", MimeType: "text/plain"},
+	}}
+	storage := &mockStorage{dataByID: map[string][]byte{"ext": []byte("dup")}}
+	svc := newBatchService(repo, storage)
+
+	results := svc.ReadContentBatch(context.Background(), []uuid.UUID{id, id, id})
+
+	if len(results) != 3 {
+		t.Fatalf("len(results) = %d, want 3", len(results))
+	}
+	for i, r := range results {
+		if !r.Found || string(r.Content) != "dup" {
+			t.Errorf("results[%d] = %+v, want found/dup", i, r)
+		}
+	}
+}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,5 +1,39 @@
 components:
   schemas:
+    http.ContentBatchItem:
+      properties:
+        contentBase64:
+          type: string
+        error:
+          type: string
+        found:
+          type: boolean
+        id:
+          type: string
+        mimeType:
+          type: string
+      required:
+        - id
+        - found
+      type: object
+    http.ContentBatchRequest:
+      properties:
+        ids:
+          items:
+            type: string
+          type: array
+      required:
+        - ids
+      type: object
+    http.ContentBatchResponse:
+      properties:
+        items:
+          items:
+            $ref: '#/components/schemas/http.ContentBatchItem'
+          type: array
+      required:
+        - items
+      type: object
     http.CopyDocumentRequest:
       properties:
         authorizationId:
@@ -262,6 +296,46 @@ paths:
         Create handles POST /internal/file — streaming ingest (spec 020): the
         file part flows request → sniff → (transcode) → staged storage without
         whole-file buffering.
+      tags:
+        - /internal
+  /internal/file/content-batch:
+    post:
+      description: |-
+        ContentBatch handles POST /internal/file/content-batch — the batched
+        counterpart to GET /internal/file/{id}/content. It takes N document ids and
+        returns N content blobs (base64) in request order, so the server's
+        derived-text resolvers can read a list of snapshot pointers in one round trip
+        instead of an N+1 of single reads.
+
+        Per-id failures are non-fatal: a malformed id, a missing document, or a
+        missing blob is reported as found=false on that item while the rest of the
+        batch still resolves — the endpoint returns 200 as long as the request itself
+        is well-formed. Wired with the same internal (no-auth) middleware as the
+        other /internal/file routes; per-blob authorization does not apply (these are
+        NULL-authz internal snapshot blobs governed by the owning document).
+      operationId: DocumentHandler.ContentBatch
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/http.ContentBatchRequest'
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/http.ContentBatchResponse'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/http.errorResponse'
+          description: Bad Request
+      summary: |-
+        ContentBatch handles POST /internal/file/content-batch — the batched
+        counterpart to GET /internal/file/{id}/content.
       tags:
         - /internal
   /internal/file/copy:


### PR DESCRIPTION
## What

Adds a **batched internal content-read endpoint** to file-service:

`POST /internal/file/content-batch` — takes **N** document ids and returns **N** content blobs (base64), **order preserved**, with per-id misses reported **non-fatally**. It's the batched counterpart to `GET /internal/file/{id}/content`, so the server's derived-text resolvers (memo `markdown` derived from the stored Yjs snapshot) can read a list of snapshot pointers in **one round trip** instead of an N+1 of single reads.

Part of workspace feature **006-collab-content-unification** (the `file-service` slice — research R1/R2). Per-document snapshot storage + optional/NULL `authorizationId` already landed in #50.

## How

- **service** (`ReadContentBatch`) — reuses the single-document read path (`GetByID` → `Storage.Read`) per id; preserves order (incl. duplicates); **no per-file authorization** (these are internal, NULL-authz snapshot blobs governed by the owning document). Per-id failures are returned, not raised.
- **http** (`ContentBatch`) — strict-decodes the body, bounds the batch (`<= 256`), echoes each raw id back at its position. Malformed id / missing row / missing blob → `found=false` with a caller-safe reason; genuine storage failures logged at Warn. Returns **200** whenever the request itself is well-formed (even an all-miss batch); **400** for an empty/oversized/malformed body.
- Wired into the **same internal (no-auth) `/internal` route group** as the other `/internal/file` endpoints.
- `openapi.yaml` regenerated (`make openapi`).

### Request / response

```jsonc
// POST /internal/file/content-batch
{ "ids": ["<uuid>", "<uuid>", ...] }              // order significant; duplicates honored

// 200
{ "items": [
  { "id": "<uuid>", "found": true,  "mimeType": "application/octet-stream", "contentBase64": "..." },
  { "id": "<uuid>", "found": false, "error": "document not found" }
] }
```

## Tests (TDD)

- **service** (`read_content_batch_test.go`) — per-blob in order, unknown doc non-fatal (wraps `ErrDocumentNotFound`), blob-read-error non-fatal, empty input, duplicates preserved.
- **http** (`content_batch_test.go`) — returns each blob, carries MIME, **order preserved** (out-of-order + duplicate ids), missing reported non-fatally (unknown doc + missing blob), invalid id in batch non-fatal, single id, empty/omitted ids → 400, over-cap → 400, at-cap → 200, malformed JSON → 400, unknown field → 400.
- **router** (`router_test.go`) — endpoint registered under the no-auth `/internal` group, resolves 200 end-to-end.

## Gates

- `make test` (race + coverage) — green
- `make lint` (golangci-lint) — 0 issues
- **Touched coverage: 100%** on all new functions (`ReadContentBatch`, `readOneContent`, `ContentBatch`, `batchItem`, `batchMissReason`) — ≥95% gate satisfied

## Dependency / base

Built on top of **#50** (`fix/optional-authorization-id`) for the NULL-authz capability — #50 is not yet in `develop`, so this PR's commit list currently includes #50's two commits (`fix(create): … optional authorizationId`, `fix(dedup): … winner re-query`). They drop out of the diff once **#50 merges into `develop`**. Please merge **#50 first**.

Ref: `workspace#006-collab-content-unification`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an internal `POST /internal/file/content-batch` endpoint to retrieve multiple document contents in one request, returning ordered per-item results (content with MIME type as base64, or per-item error without failing the whole batch).
  * Updated the API spec and handler to support the new request/response payloads.
  * Made authorization ID optional when creating documents.

* **Bug Fixes**
  * Improved deduplication handling during concurrent creates with safer retry and conflict classification.

* **Tests**
  * Added coverage for the new batching endpoint, request validation, order preservation (including duplicates), and nil/optional authorization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- pr-image-report:start -->
---
### 📦 PR image — test the current state of this PR

```bash
docker pull ghcr.io/alkem-io/file-service:pr-52
```

Current build: `ghcr.io/alkem-io/file-service:pr-52-a5727d0` · `linux/amd64` + `linux/arm64` · index digest `sha256:92420ee7a9bf81365b5bb1ecc7f692c9532eb08d9acc2da8e68c7673b4f564d9`
<!-- pr-image-report:end -->
