### PR TITLE
feat(content-batch): bounded internal batch reads with nullable create auth (006)

### DIFF
--- a/apispec.yaml
+++ b/apispec.yaml
@@ -2,6 +2,14 @@ defaults:
   requestContentType: application/json
   responseContentType: application/json
   responseStatus: 200
+typeMapping:
+  - goType: github.com/alkem-io/file-service/internal/adapter/inbound/http.ContentBatchIDs
+    openapiType:
+      type: array
+      items:
+        type: string
+      minItems: 1
+      maxItems: 256
 info:
   title: Alkemio File Service
   description: |
@@ -16,4 +24,3 @@ info:
   license:
     name: EUPL-1.2
     url: https://opensource.org/licenses/EUPL-1.2
-

--- a/db/queries/outbox.sql
+++ b/db/queries/outbox.sql
@@ -7,6 +7,11 @@
 INSERT INTO file_backup_outbox ("fileId", "externalID", priority, "createdBy", "createdDate", size)
 VALUES ($1, $2, $3, $4, $5, $6);
 
+-- name: NotifyBackupOutbox :exec
+-- Best-effort post-commit wake for the backup worker after an outbox row is recorded. A lost
+-- NOTIFY is covered by the durable table + the worker's poll floor, so callers ignore the error.
+NOTIFY file_backup_outbox;
+
 -- name: PruneBackupOutboxDone :execrows
 -- Keep the outbox bounded (SC-008): drop rows the consumer already finished (status='done')
 -- older than a retention cutoff. The ledger (file-backup-service's own DB) keeps the durable

--- a/internal/adapter/inbound/http/content_batch_handler.go
+++ b/internal/adapter/inbound/http/content_batch_handler.go
@@ -1,0 +1,125 @@
+package http
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+
+	"github.com/alkem-io/file-service/internal/domain/model"
+	"github.com/alkem-io/file-service/internal/domain/service"
+)
+
+const (
+	// 256 covers the derived-text resolver's page fan-in while bounding DB and
+	// storage work; callers with more ids page the request.
+	maxContentBatchSize = 256
+	// A canonical 256-UUID request is under 10 KiB. Leave headroom for JSON
+	// whitespace while rejecting oversized bodies before the decoder allocates.
+	maxContentBatchRequestBytes int64 = 16 << 10
+	// Let one file at the historical upload ceiling fit while preventing a
+	// 256-item request from accumulating gigabytes of raw and base64 data.
+	maxContentBatchResponseBytes int64 = 32 << 20
+)
+
+// ContentBatch handles POST /internal/file/content-batch. Results preserve
+// request order and report malformed ids and missing content per item.
+func (h *DocumentHandler) ContentBatch(w http.ResponseWriter, r *http.Request) {
+	var body ContentBatchRequest
+	if !decodeContentBatchRequest(w, r, &body) {
+		return
+	}
+
+	if len(body.Ids) == 0 {
+		writeJSONError(w, http.StatusBadRequest, "ids must not be empty")
+		return
+	}
+	if len(body.Ids) > maxContentBatchSize {
+		writeJSONError(w, http.StatusBadRequest, "too many ids in one batch")
+		return
+	}
+
+	type parsedID struct {
+		raw    string
+		parsed *uuid.UUID
+	}
+	parsed := make([]parsedID, len(body.Ids))
+	validIDs := make([]uuid.UUID, 0, len(body.Ids))
+	for i, raw := range body.Ids {
+		id, err := uuid.Parse(raw)
+		if err != nil {
+			parsed[i] = parsedID{raw: raw}
+			continue
+		}
+		parsed[i] = parsedID{raw: raw, parsed: &id}
+		validIDs = append(validIDs, id)
+	}
+
+	results := h.Service.ReadContentBatch(r.Context(), validIDs, maxContentBatchResponseBytes)
+
+	items := make([]ContentBatchItem, len(parsed))
+	resultIdx := 0
+	for i, p := range parsed {
+		if p.parsed == nil {
+			items[i] = ContentBatchItem{ID: p.raw, Found: false, Error: "invalid id"}
+			continue
+		}
+		items[i] = h.batchItem(p.raw, results[resultIdx])
+		resultIdx++
+	}
+
+	ContentBatchResponse{Items: items}.Render(w)
+}
+
+func decodeContentBatchRequest(w http.ResponseWriter, r *http.Request, dst *ContentBatchRequest) bool {
+	dec := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxContentBatchRequestBytes))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(dst); err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			writeJSONError(w, http.StatusRequestEntityTooLarge, "request body too large")
+			return false
+		}
+		writeJSONError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+		return false
+	}
+	var trailing json.RawMessage
+	if err := dec.Decode(&trailing); !errors.Is(err, io.EOF) {
+		writeJSONError(w, http.StatusBadRequest, "invalid JSON body: trailing data after first object")
+		return false
+	}
+	return true
+}
+
+func (h *DocumentHandler) batchItem(rawID string, res service.BatchContentResult) ContentBatchItem {
+	if res.Found {
+		return ContentBatchItem{
+			ID:            rawID,
+			Found:         true,
+			MimeType:      res.MimeType,
+			ContentBase64: base64.StdEncoding.EncodeToString(res.Content),
+		}
+	}
+	if res.Err != nil &&
+		!errors.Is(res.Err, model.ErrDocumentNotFound) &&
+		!errors.Is(res.Err, service.ErrBatchContentLimit) &&
+		h.Logger != nil {
+		h.Logger.Warn("content-batch: content read failed for id",
+			zap.String("id", rawID), zap.Error(res.Err))
+	}
+	return ContentBatchItem{ID: rawID, Found: false, Error: batchMissReason(res.Err)}
+}
+
+func batchMissReason(err error) string {
+	if errors.Is(err, model.ErrDocumentNotFound) {
+		return "document not found"
+	}
+	if errors.Is(err, service.ErrBatchContentLimit) {
+		return "batch content limit exceeded"
+	}
+	return "content unavailable"
+}

--- a/internal/adapter/inbound/http/content_batch_handler.go
+++ b/internal/adapter/inbound/http/content_batch_handler.go
@@ -2,10 +2,9 @@ package http
 
 import (
 	"encoding/base64"
-	"encoding/json"
 	"errors"
-	"io"
 	"net/http"
+	"os"
 
 	"github.com/google/uuid"
 	"go.uber.org/zap"
@@ -76,23 +75,18 @@ func (h *DocumentHandler) ContentBatch(w http.ResponseWriter, r *http.Request) {
 }
 
 func decodeContentBatchRequest(w http.ResponseWriter, r *http.Request, dst *ContentBatchRequest) bool {
-	dec := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxContentBatchRequestBytes))
-	dec.DisallowUnknownFields()
-	if err := dec.Decode(dst); err != nil {
-		var maxBytesErr *http.MaxBytesError
-		if errors.As(err, &maxBytesErr) {
-			writeJSONError(w, http.StatusRequestEntityTooLarge, "request body too large")
-			return false
-		}
-		writeJSONError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+	r.Body = http.MaxBytesReader(w, r.Body, maxContentBatchRequestBytes)
+	err := decodeStrictJSON(r, dst)
+	if err == nil {
+		return true
+	}
+	var maxBytesErr *http.MaxBytesError
+	if errors.As(err, &maxBytesErr) {
+		writeJSONError(w, http.StatusRequestEntityTooLarge, "request body too large")
 		return false
 	}
-	var trailing json.RawMessage
-	if err := dec.Decode(&trailing); !errors.Is(err, io.EOF) {
-		writeJSONError(w, http.StatusBadRequest, "invalid JSON body: trailing data after first object")
-		return false
-	}
-	return true
+	writeJSONError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+	return false
 }
 
 func (h *DocumentHandler) batchItem(rawID string, res service.BatchContentResult) ContentBatchItem {
@@ -118,8 +112,11 @@ func batchMissReason(err error) string {
 	if errors.Is(err, model.ErrDocumentNotFound) {
 		return "document not found"
 	}
+	if errors.Is(err, os.ErrNotExist) {
+		return "content not found"
+	}
 	if errors.Is(err, service.ErrBatchContentLimit) {
 		return "batch content limit exceeded"
 	}
-	return "content unavailable"
+	return "backend unavailable"
 }

--- a/internal/adapter/inbound/http/content_batch_test.go
+++ b/internal/adapter/inbound/http/content_batch_test.go
@@ -1,0 +1,343 @@
+package http
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+
+	"github.com/alkem-io/file-service/internal/domain/model"
+	"github.com/alkem-io/file-service/internal/domain/service"
+)
+
+// runContentBatch wires a fresh handler + chi router and dispatches a single
+// POST /internal/file/content-batch request with the given JSON body. The
+// configure callback (if non-nil) seeds mock state on the repo + storage
+// before the request is served. Returns the response recorder so callers can
+// assert status + body without repeating chi/httptest boilerplate.
+func runContentBatch(t *testing.T, body string, configure func(*mockDocRepo, *mockStorage)) *httptest.ResponseRecorder {
+	t.Helper()
+	h, repo, storage := newDocHandler()
+	if configure != nil {
+		configure(repo, storage)
+	}
+	r := chi.NewRouter()
+	r.Post("/internal/file/content-batch", h.ContentBatch)
+
+	req := httptest.NewRequest(http.MethodPost, "/internal/file/content-batch", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+	return rr
+}
+
+func decodeBatchResponse(t *testing.T, rr *httptest.ResponseRecorder) ContentBatchResponse {
+	t.Helper()
+	var resp ContentBatchResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v (body: %s)", err, rr.Body.String())
+	}
+	return resp
+}
+
+func TestContentBatch_ReturnsEachBlob(t *testing.T) {
+	id1, id2 := uuid.New(), uuid.New()
+	want := map[uuid.UUID]string{id1: "snapshot-one", id2: "snapshot-two"}
+
+	rr := runContentBatch(t, `{"ids":["`+id1.String()+`","`+id2.String()+`"]}`, func(repo *mockDocRepo, storage *mockStorage) {
+		repo.docsByID = map[uuid.UUID]model.Document{
+			id1: {ID: id1, ExternalID: "ext-1", MimeType: "application/octet-stream"},
+			id2: {ID: id2, ExternalID: "ext-2", MimeType: "text/plain"},
+		}
+		storage.blobsByExternalID = map[string][]byte{
+			"ext-1": []byte(want[id1]),
+			"ext-2": []byte(want[id2]),
+		}
+	})
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200, body: %s", rr.Code, rr.Body.String())
+	}
+	resp := decodeBatchResponse(t, rr)
+	if len(resp.Items) != 2 {
+		t.Fatalf("len(items) = %d, want 2", len(resp.Items))
+	}
+	for _, item := range resp.Items {
+		id := uuid.MustParse(item.ID)
+		if !item.Found {
+			t.Errorf("id %s: found = false, want true", id)
+			continue
+		}
+		decoded, err := base64.StdEncoding.DecodeString(item.ContentBase64)
+		if err != nil {
+			t.Errorf("id %s: base64 decode: %v", id, err)
+			continue
+		}
+		if string(decoded) != want[id] {
+			t.Errorf("id %s: content = %q, want %q", id, decoded, want[id])
+		}
+	}
+}
+
+func TestContentBatch_CarriesMimeType(t *testing.T) {
+	id := uuid.New()
+	rr := runContentBatch(t, `{"ids":["`+id.String()+`"]}`, func(repo *mockDocRepo, storage *mockStorage) {
+		repo.docsByID = map[uuid.UUID]model.Document{
+			id: {ID: id, ExternalID: "ext", MimeType: "application/x-yjs-snapshot"},
+		}
+		storage.blobsByExternalID = map[string][]byte{"ext": []byte("data")}
+	})
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	resp := decodeBatchResponse(t, rr)
+	if len(resp.Items) != 1 {
+		t.Fatalf("len(items) = %d, want 1", len(resp.Items))
+	}
+	if resp.Items[0].MimeType != "application/x-yjs-snapshot" {
+		t.Errorf("mimeType = %q, want application/x-yjs-snapshot", resp.Items[0].MimeType)
+	}
+}
+
+func TestContentBatch_PreservesOrder(t *testing.T) {
+	a, b, c := uuid.New(), uuid.New(), uuid.New()
+	// Deliberately request out of "natural" order, with a repeat (a appears twice).
+	order := []uuid.UUID{c, a, b, a}
+	quoted := make([]string, len(order))
+	for i, id := range order {
+		quoted[i] = `"` + id.String() + `"`
+	}
+
+	rr := runContentBatch(t, `{"ids":[`+strings.Join(quoted, ",")+`]}`, func(repo *mockDocRepo, storage *mockStorage) {
+		repo.docsByID = map[uuid.UUID]model.Document{
+			a: {ID: a, ExternalID: "ext-a", MimeType: "text/plain"},
+			b: {ID: b, ExternalID: "ext-b", MimeType: "text/plain"},
+			c: {ID: c, ExternalID: "ext-c", MimeType: "text/plain"},
+		}
+		storage.blobsByExternalID = map[string][]byte{
+			"ext-a": []byte("AAA"),
+			"ext-b": []byte("BBB"),
+			"ext-c": []byte("CCC"),
+		}
+	})
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200, body: %s", rr.Code, rr.Body.String())
+	}
+	resp := decodeBatchResponse(t, rr)
+	if len(resp.Items) != len(order) {
+		t.Fatalf("len(items) = %d, want %d (one per requested id, duplicates preserved)", len(resp.Items), len(order))
+	}
+	for i, item := range resp.Items {
+		wantID := order[i]
+		if item.ID != wantID.String() {
+			t.Errorf("items[%d].id = %s, want %s (order not preserved)", i, item.ID, wantID)
+		}
+	}
+}
+
+func TestContentBatch_MissingReportedNonFatally(t *testing.T) {
+	present := uuid.New()
+	unknownDoc := uuid.New()  // no repo row
+	blobMissing := uuid.New() // repo row exists, blob absent from storage
+	order := []uuid.UUID{present, unknownDoc, blobMissing}
+	quoted := make([]string, len(order))
+	for i, id := range order {
+		quoted[i] = `"` + id.String() + `"`
+	}
+
+	rr := runContentBatch(t, `{"ids":[`+strings.Join(quoted, ",")+`]}`, func(repo *mockDocRepo, storage *mockStorage) {
+		repo.docsByID = map[uuid.UUID]model.Document{
+			present:     {ID: present, ExternalID: "ext-present", MimeType: "text/plain"},
+			blobMissing: {ID: blobMissing, ExternalID: "ext-gone", MimeType: "text/plain"},
+			// unknownDoc intentionally absent → GetByID returns ErrDocumentNotFound.
+		}
+		storage.blobsByExternalID = map[string][]byte{
+			"ext-present": []byte("here"),
+			// "ext-gone" intentionally absent → Read returns os.ErrNotExist.
+		}
+	})
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (partial miss is non-fatal), body: %s", rr.Code, rr.Body.String())
+	}
+	resp := decodeBatchResponse(t, rr)
+	if len(resp.Items) != 3 {
+		t.Fatalf("len(items) = %d, want 3", len(resp.Items))
+	}
+
+	if !resp.Items[0].Found || resp.Items[0].ContentBase64 == "" {
+		t.Errorf("items[0] (present) found=%v content=%q, want found + content", resp.Items[0].Found, resp.Items[0].ContentBase64)
+	}
+	for i, label := range map[int]string{1: "unknown-doc", 2: "blob-missing"} {
+		if resp.Items[i].Found {
+			t.Errorf("items[%d] (%s) found = true, want false", i, label)
+		}
+		if resp.Items[i].Error == "" {
+			t.Errorf("items[%d] (%s) error empty, want a non-fatal reason", i, label)
+		}
+		if resp.Items[i].ContentBase64 != "" {
+			t.Errorf("items[%d] (%s) content non-empty on a miss", i, label)
+		}
+	}
+}
+
+func TestContentBatch_InvalidIDInBatchNonFatal(t *testing.T) {
+	good := uuid.New()
+	rr := runContentBatch(t, `{"ids":["`+good.String()+`","not-a-uuid"]}`, func(repo *mockDocRepo, storage *mockStorage) {
+		repo.docsByID = map[uuid.UUID]model.Document{
+			good: {ID: good, ExternalID: "ext", MimeType: "text/plain"},
+		}
+		storage.blobsByExternalID = map[string][]byte{"ext": []byte("ok")}
+	})
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200, body: %s", rr.Code, rr.Body.String())
+	}
+	resp := decodeBatchResponse(t, rr)
+	if len(resp.Items) != 2 {
+		t.Fatalf("len(items) = %d, want 2", len(resp.Items))
+	}
+	if !resp.Items[0].Found {
+		t.Errorf("items[0] (valid id) found = false, want true")
+	}
+	if resp.Items[0].ID != good.String() {
+		t.Errorf("items[0].id = %s, want %s", resp.Items[0].ID, good)
+	}
+	if resp.Items[1].Found {
+		t.Errorf("items[1] (invalid id) found = true, want false")
+	}
+	if resp.Items[1].ID != "not-a-uuid" {
+		t.Errorf("items[1].id = %q, want the malformed id echoed back", resp.Items[1].ID)
+	}
+	if resp.Items[1].Error == "" {
+		t.Errorf("items[1] (invalid id) error empty, want a reason")
+	}
+}
+
+func TestContentBatch_SingleID(t *testing.T) {
+	id := uuid.New()
+	rr := runContentBatch(t, `{"ids":["`+id.String()+`"]}`, func(repo *mockDocRepo, storage *mockStorage) {
+		repo.docsByID = map[uuid.UUID]model.Document{id: {ID: id, ExternalID: "ext", MimeType: "text/plain"}}
+		storage.blobsByExternalID = map[string][]byte{"ext": []byte("solo")}
+	})
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	resp := decodeBatchResponse(t, rr)
+	if len(resp.Items) != 1 || !resp.Items[0].Found {
+		t.Fatalf("items = %+v, want one found item", resp.Items)
+	}
+	decoded, err := base64.StdEncoding.DecodeString(resp.Items[0].ContentBase64)
+	if err != nil {
+		t.Fatalf("base64 decode failed: %v", err)
+	}
+	if string(decoded) != "solo" {
+		t.Errorf("content = %q, want %q", decoded, "solo")
+	}
+}
+
+func TestContentBatch_EmptyIDs_400(t *testing.T) {
+	rr := runContentBatch(t, `{"ids":[]}`, nil)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 for empty ids", rr.Code)
+	}
+}
+
+func TestContentBatch_OmittedIDs_400(t *testing.T) {
+	rr := runContentBatch(t, `{}`, nil)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 for omitted ids", rr.Code)
+	}
+}
+
+func TestContentBatch_TooManyIDs_400(t *testing.T) {
+	ids := make([]string, maxContentBatchSize+1)
+	for i := range ids {
+		ids[i] = `"` + uuid.New().String() + `"`
+	}
+	rr := runContentBatch(t, `{"ids":[`+strings.Join(ids, ",")+`]}`, nil)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 for over-cap batch", rr.Code)
+	}
+}
+
+func TestContentBatch_AtCap_OK(t *testing.T) {
+	ids := make([]string, maxContentBatchSize)
+	for i := range ids {
+		ids[i] = `"` + uuid.New().String() + `"`
+	}
+	// No docs seeded → every item resolves as a non-fatal miss, but the
+	// request itself is accepted (200), which is what this boundary asserts.
+	rr := runContentBatch(t, `{"ids":[`+strings.Join(ids, ",")+`]}`, func(repo *mockDocRepo, _ *mockStorage) {
+		repo.docsByID = map[uuid.UUID]model.Document{} // empty, id-aware → all miss
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 at exactly the cap, body: %s", rr.Code, rr.Body.String())
+	}
+	resp := decodeBatchResponse(t, rr)
+	if len(resp.Items) != maxContentBatchSize {
+		t.Fatalf("len(items) = %d, want %d", len(resp.Items), maxContentBatchSize)
+	}
+}
+
+func TestContentBatch_MalformedJSON_400(t *testing.T) {
+	rr := runContentBatch(t, `{"ids":[`, nil)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 for malformed JSON", rr.Code)
+	}
+}
+
+func TestContentBatch_TrailingJSON_400(t *testing.T) {
+	id := uuid.New()
+	rr := runContentBatch(t, `{"ids":["`+id.String()+`"]} {}`, nil)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 for trailing JSON", rr.Code)
+	}
+}
+
+func TestContentBatch_OversizedBody_413BeforeLookup(t *testing.T) {
+	var repoRef *mockDocRepo
+	body := `{"ids":["` + strings.Repeat("x", int(maxContentBatchRequestBytes)) + `"]}`
+	rr := runContentBatch(t, body, func(repo *mockDocRepo, _ *mockStorage) {
+		repoRef = repo
+	})
+
+	if rr.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want 413 for oversized body", rr.Code)
+	}
+	if repoRef.getByIDCalls != 0 {
+		t.Fatalf("GetByID calls = %d, want 0 for rejected body", repoRef.getByIDCalls)
+	}
+}
+
+func TestBatchItem_NilLoggerIsSafe(t *testing.T) {
+	item := (&DocumentHandler{}).batchItem("id", service.BatchContentResult{
+		Err: errors.New("storage unavailable"),
+	})
+	if item.Found || item.Error != "content unavailable" {
+		t.Fatalf("item = %+v, want caller-safe miss", item)
+	}
+}
+
+func TestBatchMissReason_ContentLimit(t *testing.T) {
+	if got := batchMissReason(service.ErrBatchContentLimit); got != "batch content limit exceeded" {
+		t.Fatalf("reason = %q", got)
+	}
+}
+
+func TestContentBatch_UnknownField_400(t *testing.T) {
+	id := uuid.New()
+	rr := runContentBatch(t, `{"ids":["`+id.String()+`"],"surprise":true}`, nil)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 for unknown field", rr.Code)
+	}
+}

--- a/internal/adapter/inbound/http/content_batch_test.go
+++ b/internal/adapter/inbound/http/content_batch_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 
@@ -323,8 +324,17 @@ func TestBatchItem_NilLoggerIsSafe(t *testing.T) {
 	item := (&DocumentHandler{}).batchItem("id", service.BatchContentResult{
 		Err: errors.New("storage unavailable"),
 	})
-	if item.Found || item.Error != "content unavailable" {
-		t.Fatalf("item = %+v, want caller-safe miss", item)
+	if item.Found || item.Error != "backend unavailable" {
+		t.Fatalf("item = %+v, want caller-safe backend failure", item)
+	}
+}
+
+func TestBatchMissReason_MissingBlobIsDistinctFromBackendFailure(t *testing.T) {
+	if got := batchMissReason(os.ErrNotExist); got != "content not found" {
+		t.Fatalf("missing content reason = %q", got)
+	}
+	if got := batchMissReason(errors.New("database unavailable")); got != "backend unavailable" {
+		t.Fatalf("backend failure reason = %q", got)
 	}
 }
 

--- a/internal/adapter/inbound/http/document_handler.go
+++ b/internal/adapter/inbound/http/document_handler.go
@@ -202,6 +202,19 @@ func parseOptionalUUID(value, field string) (*uuid.UUID, error) {
 	return &parsed, nil
 }
 
+// parseCreateAuthorizationID accepts omission as uuid.Nil (the domain's
+// explicit SQL-NULL signal) but rejects an explicitly supplied all-zero UUID.
+func parseCreateAuthorizationID(value string) (uuid.UUID, error) {
+	if value == "" {
+		return uuid.Nil, nil
+	}
+	parsed, err := uuid.Parse(value)
+	if err != nil || parsed == uuid.Nil {
+		return uuid.Nil, fmt.Errorf("invalid authorizationId")
+	}
+	return parsed, nil
+}
+
 // parseOptionalBool parses an optional boolean form field: empty means
 // false. The error names the field so it can serve directly as a 400 body.
 func parseOptionalBool(value, field string) (bool, error) {
@@ -227,9 +240,9 @@ func buildCreateInput(fields createFields) (input model.CreateDocumentInput, all
 		return input, nil, 0, fmt.Errorf("invalid storageBucketId")
 	}
 
-	authorizationID, err := uuid.Parse(fields.authorizationID)
+	authorizationID, err := parseCreateAuthorizationID(fields.authorizationID)
 	if err != nil {
-		return input, nil, 0, fmt.Errorf("invalid authorizationId")
+		return input, nil, 0, err
 	}
 
 	tagsetID, err := parseOptionalUUID(fields.tagsetID, "tagsetId")
@@ -416,8 +429,8 @@ func (h *DocumentHandler) readMetadataField(w http.ResponseWriter, fields *creat
 
 // writeCompleteUploadError maps a CompleteUpload failure to its HTTP
 // response and outcome counter (spec 020 FR-008): bucket-policy rejections
-// (size, MIME) are 413/415, a SkipDedup content collision is 409, anything
-// else is a logged 500.
+// (size, MIME) are 413/415, uniqueness conflicts are 409, anything else is
+// a logged 500.
 func (h *DocumentHandler) writeCompleteUploadError(w http.ResponseWriter, err error) {
 	switch {
 	case errors.Is(err, service.ErrPayloadTooLarge):
@@ -427,7 +440,7 @@ func (h *DocumentHandler) writeCompleteUploadError(w http.ResponseWriter, err er
 		IngestOutcomes.Add("rejected_bucket_policy", 1)
 		writeJSONError(w, http.StatusUnsupportedMediaType, "unsupported media type")
 	case errors.Is(err, service.ErrConflict):
-		writeJSONError(w, http.StatusConflict, "skipDedup requested but a row with this content already exists in the bucket")
+		writeJSONError(w, http.StatusConflict, "document conflicts with an existing row")
 	default:
 		IngestOutcomes.Add("failed_mid_stream", 1)
 		h.Logger.Error("failed to create document", zap.Error(err))
@@ -529,12 +542,12 @@ func (h *DocumentHandler) Copy(w http.ResponseWriter, r *http.Request) {
 	doc, err := h.Service.CopyDocument(r.Context(), sourceID, input)
 	if err != nil {
 		switch {
+		case errors.Is(err, service.ErrInvalidAuthorizationID):
+			writeJSONError(w, http.StatusBadRequest, "invalid authorizationId")
 		case errors.Is(err, model.ErrDocumentNotFound):
 			writeJSONError(w, http.StatusNotFound, "source document not found")
 		case errors.Is(err, service.ErrConflict):
-			// Reachable only when SkipDedup=true and the destination bucket
-			// already has a row with this content under the unique index.
-			writeJSONError(w, http.StatusConflict, "skipDedup requested but a row with this content already exists in the destination bucket")
+			writeJSONError(w, http.StatusConflict, "copy conflicts with an existing row")
 		default:
 			h.Logger.Error("failed to copy document", zap.Error(err))
 			writeJSONError(w, http.StatusInternalServerError, "internal error")

--- a/internal/adapter/inbound/http/document_handler.go
+++ b/internal/adapter/inbound/http/document_handler.go
@@ -491,7 +491,8 @@ func isClientStreamError(err error) bool {
 // (existing row is authoritative), matching the createDocument contract.
 func (h *DocumentHandler) Copy(w http.ResponseWriter, r *http.Request) {
 	var body CopyDocumentRequest
-	if !decodeStrictJSON(w, r, &body) {
+	if err := decodeStrictJSON(r, &body); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
 		return
 	}
 
@@ -585,8 +586,10 @@ func (h *DocumentHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resp := DeleteDocumentResponse{
-		AuthorizationID: deleted.AuthorizationID.String(),
+	resp := DeleteDocumentResponse{}
+	if deleted.AuthorizationID != uuid.Nil {
+		s := deleted.AuthorizationID.String()
+		resp.AuthorizationID = &s
 	}
 	if deleted.TagsetID != nil {
 		s := deleted.TagsetID.String()
@@ -617,7 +620,8 @@ func (h *DocumentHandler) Update(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var body UpdateDocumentRequest
-	if !decodeStrictJSON(w, r, &body) {
+	if err := decodeStrictJSON(r, &body); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
 		return
 	}
 
@@ -782,24 +786,21 @@ func parseDocID(r *http.Request) (uuid.UUID, error) {
 }
 
 // decodeStrictJSON decodes the request body into dst, rejecting unknown
-// fields and any trailing data after the first JSON object. It reports true
-// on success; on failure it returns false AFTER writing the 400 response
-// itself, so callers must simply return without touching w further.
+// fields and any trailing data after the first JSON object.
 //
 // DisallowUnknownFields is load-bearing: immutable fields (e.g. mimeType on
 // PATCH) must surface as a 400 rather than silently no-op.
-func decodeStrictJSON[T any](w http.ResponseWriter, r *http.Request, dst *T) bool {
+func decodeStrictJSON[T any](r *http.Request, dst *T) error {
 	dec := json.NewDecoder(r.Body)
 	dec.DisallowUnknownFields()
 	if err := dec.Decode(dst); err != nil {
-		writeJSONError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
-		return false
+		return err
 	}
-	if dec.More() {
-		writeJSONError(w, http.StatusBadRequest, "invalid JSON body: trailing data after first object")
-		return false
+	var trailing json.RawMessage
+	if err := dec.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return errors.New("trailing data after first object")
 	}
-	return true
+	return nil
 }
 
 // resolveBucketID resolves the effective storage bucket for a PATCH: the

--- a/internal/adapter/inbound/http/document_handler_test.go
+++ b/internal/adapter/inbound/http/document_handler_test.go
@@ -261,6 +261,57 @@ func TestDocumentHandler_Create_Success(t *testing.T) {
 	}
 }
 
+func TestDocumentHandler_Create_OmittedAuthorization_CreatesNullAuthRow(t *testing.T) {
+	h, repo, _ := newDocHandler()
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	part, _ := writer.CreateFormFile("file", "snapshot.ybin")
+	_, _ = part.Write([]byte("snapshot"))
+	_ = writer.WriteField("displayName", "snapshot.ybin")
+	_ = writer.WriteField("storageBucketId", uuid.New().String())
+	// authorizationId deliberately omitted.
+	_ = writer.Close()
+
+	r := chi.NewRouter()
+	r.Post("/internal/file", h.Create)
+	req := httptest.NewRequest(http.MethodPost, "/internal/file", &body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201, body: %s", rr.Code, rr.Body.String())
+	}
+	if repo.lastCreateDoc.AuthorizationID != uuid.Nil {
+		t.Fatalf("repo authorizationId = %s, want uuid.Nil (SQL NULL)", repo.lastCreateDoc.AuthorizationID)
+	}
+}
+
+func TestDocumentHandler_Create_ExplicitNilAuthorization_400(t *testing.T) {
+	h, _, _ := newDocHandler()
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	part, _ := writer.CreateFormFile("file", "snapshot.ybin")
+	_, _ = part.Write([]byte("snapshot"))
+	_ = writer.WriteField("displayName", "snapshot.ybin")
+	_ = writer.WriteField("storageBucketId", uuid.New().String())
+	_ = writer.WriteField("authorizationId", uuid.Nil.String())
+	_ = writer.Close()
+
+	r := chi.NewRouter()
+	r.Post("/internal/file", h.Create)
+	req := httptest.NewRequest(http.MethodPost, "/internal/file", &body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400, body: %s", rr.Code, rr.Body.String())
+	}
+}
+
 func TestDocumentHandler_Create_Success_NotReused(t *testing.T) {
 	h, _, _ := newDocHandler()
 
@@ -403,6 +454,33 @@ func TestDocumentHandler_Create_SkipDedup_Conflict_Returns409(t *testing.T) {
 	r := chi.NewRouter()
 	r.Post("/internal/file", h.Create)
 
+	req := httptest.NewRequest(http.MethodPost, "/internal/file", &body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409, body: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestDocumentHandler_Create_AuthorizationCollision_Returns409(t *testing.T) {
+	h, repo, _ := newDocHandler()
+	// No (externalID, bucket) winner exists in the default mock, so this
+	// unique violation represents authorizationId/tagsetId reuse.
+	repo.createErr = model.ErrDuplicateKey
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	part, _ := writer.CreateFormFile("file", "snapshot.ybin")
+	_, _ = part.Write([]byte("snapshot"))
+	_ = writer.WriteField("displayName", "snapshot.ybin")
+	_ = writer.WriteField("storageBucketId", uuid.New().String())
+	_ = writer.WriteField("authorizationId", uuid.New().String())
+	_ = writer.Close()
+
+	r := chi.NewRouter()
+	r.Post("/internal/file", h.Create)
 	req := httptest.NewRequest(http.MethodPost, "/internal/file", &body)
 	req.Header.Set("Content-Type", writer.FormDataContentType())
 	rr := httptest.NewRecorder()
@@ -575,6 +653,26 @@ func TestDocumentHandler_Copy_InvalidSourceID_400(t *testing.T) {
 
 	if rr.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400", rr.Code)
+	}
+}
+
+func TestDocumentHandler_Copy_NilAuthorizationID_400(t *testing.T) {
+	h, _, _ := newDocHandler()
+
+	body, _ := json.Marshal(CopyDocumentRequest{
+		SourceID:            uuid.New().String(),
+		DestinationBucketID: uuid.New().String(),
+		AuthorizationID:     uuid.Nil.String(),
+	})
+	r := chi.NewRouter()
+	r.Post("/internal/file/copy", h.Copy)
+	req := httptest.NewRequest(http.MethodPost, "/internal/file/copy", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400, body: %s", rr.Code, rr.Body.String())
 	}
 }
 

--- a/internal/adapter/inbound/http/document_handler_test.go
+++ b/internal/adapter/inbound/http/document_handler_test.go
@@ -922,6 +922,41 @@ func TestDocumentHandler_Delete_Success(t *testing.T) {
 	if rr.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200, body: %s", rr.Code, rr.Body.String())
 	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp["authorizationId"] != authID.String() {
+		t.Fatalf("authorizationId = %v, want %s", resp["authorizationId"], authID)
+	}
+}
+
+func TestDocumentHandler_Delete_NullAuthorizationIsOmitted(t *testing.T) {
+	h, repo, _ := newDocHandler()
+	docID := uuid.New()
+	repo.doc = model.Document{ID: docID, ExternalID: "snapshot"}
+	repo.deleteResult = model.DeletedDocument{AuthorizationID: uuid.Nil}
+	repo.count = 1
+
+	r := chi.NewRouter()
+	r.Delete("/internal/file/{id}", h.Delete)
+
+	req := httptest.NewRequest(http.MethodDelete, "/internal/file/"+docID.String(), nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200, body: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if _, present := resp["authorizationId"]; present {
+		t.Fatalf("authorizationId must be omitted for a NULL policy, body: %s", rr.Body.String())
+	}
 }
 
 func TestDocumentHandler_Patch_Success(t *testing.T) {

--- a/internal/adapter/inbound/http/dto.go
+++ b/internal/adapter/inbound/http/dto.go
@@ -143,6 +143,32 @@ type UpdateDocumentRequest struct {
 	DisplayName       *string `json:"displayName,omitempty"`
 }
 
+// ContentBatchRequest preserves id order and duplicates.
+type ContentBatchRequest struct {
+	Ids []string `json:"ids"`
+}
+
+// ContentBatchItem is the positional outcome for one requested id.
+type ContentBatchItem struct {
+	ID            string `json:"id"`
+	Found         bool   `json:"found"`
+	MimeType      string `json:"mimeType,omitempty"`
+	ContentBase64 string `json:"contentBase64,omitempty"`
+	Error         string `json:"error,omitempty"`
+}
+
+// ContentBatchResponse preserves request order, including duplicate ids.
+type ContentBatchResponse struct {
+	Items []ContentBatchItem `json:"items"`
+}
+
+// Render writes the response as JSON with HTTP 200.
+func (r ContentBatchResponse) Render(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(r)
+}
+
 // CopyDocumentRequest is the JSON body for POST /internal/file/copy.
 // Reuses CreateDocumentResponse for the response shape.
 type CopyDocumentRequest struct {

--- a/internal/adapter/inbound/http/dto.go
+++ b/internal/adapter/inbound/http/dto.go
@@ -36,7 +36,7 @@ func (r CreateDocumentResponse) Render(w http.ResponseWriter) {
 
 // DeleteDocumentResponse is returned by DELETE /internal/document/:id.
 type DeleteDocumentResponse struct {
-	AuthorizationID string  `json:"authorizationId"`
+	AuthorizationID *string `json:"authorizationId,omitempty"`
 	TagsetID        *string `json:"tagsetId,omitempty"`
 }
 
@@ -143,9 +143,12 @@ type UpdateDocumentRequest struct {
 	DisplayName       *string `json:"displayName,omitempty"`
 }
 
+// ContentBatchIDs is the bounded, ordered id list accepted by ContentBatch.
+type ContentBatchIDs []string
+
 // ContentBatchRequest preserves id order and duplicates.
 type ContentBatchRequest struct {
-	Ids []string `json:"ids"`
+	Ids ContentBatchIDs `json:"ids"`
 }
 
 // ContentBatchItem is the positional outcome for one requested id.

--- a/internal/adapter/inbound/http/public_handler.go
+++ b/internal/adapter/inbound/http/public_handler.go
@@ -48,6 +48,10 @@ func (h *PublicHandler) ServeDocument(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusInternalServerError, "internal error")
 		return
 	}
+	if doc.AuthorizationID == uuid.Nil {
+		writeJSONError(w, http.StatusForbidden, "insufficient privileges")
+		return
+	}
 
 	// Authorization check via h2c HTTP/2 (or NATS fallback). For anonymous
 	// callers, actorID is empty — the auth-evaluation-service treats that

--- a/internal/adapter/inbound/http/public_handler_test.go
+++ b/internal/adapter/inbound/http/public_handler_test.go
@@ -31,6 +31,13 @@ type mockDocRepo struct {
 	count        int
 	getByIDCalls int // asserts the by-hash blob endpoint never does a document lookup
 
+	// docsByID, when non-nil, makes GetByID id-aware: it returns the mapped
+	// document for a known id and model.ErrDocumentNotFound for an unknown
+	// one. Used by the batched-read tests, which need several distinct rows
+	// in one request. When nil, GetByID falls back to the single doc/err
+	// pair above so every existing single-document test is unaffected.
+	docsByID map[uuid.UUID]model.Document
+
 	// Captured args from the most recent UpdateMetadata call.
 	updateMetadataCalls   int
 	lastUpdateBucketID    uuid.UUID
@@ -51,8 +58,14 @@ type mockDocRepo struct {
 	backfillErr            error
 }
 
-func (m *mockDocRepo) GetByID(_ context.Context, _ uuid.UUID) (model.Document, error) {
+func (m *mockDocRepo) GetByID(_ context.Context, id uuid.UUID) (model.Document, error) {
 	m.getByIDCalls++
+	if m.docsByID != nil {
+		if doc, ok := m.docsByID[id]; ok {
+			return doc, nil
+		}
+		return model.Document{}, model.ErrDocumentNotFound
+	}
 	return m.doc, m.err
 }
 func (m *mockDocRepo) FindByExternalIDAndBucket(_ context.Context, _ string, _ uuid.UUID) (model.Document, error) {
@@ -136,6 +149,8 @@ type mockStorage struct {
 	stages     []*httpMockStage
 	streamBody io.ReadCloser // if set, ReadStream returns this (to inject a mid-stream read failure)
 	streamSize int64         // Content-Length ReadStream reports when streamBody is set
+	// Per-blob data for batch tests; nil keeps the existing flat mock behavior.
+	blobsByExternalID map[string][]byte
 }
 
 // failingReadCloser yields `head` then fails — a mid-stream backend read fault (NFS EIO/ESTALE).
@@ -174,13 +189,27 @@ func (m *mockStorage) Save(content []byte) (model.StoredFile, error) {
 	}
 	return model.StoredFile{ExternalID: "hash", Size: len(content), Created: true}, nil
 }
-func (m *mockStorage) Read(_ string) ([]byte, error) { return m.data, m.err }
+func (m *mockStorage) Read(externalID string) ([]byte, error) {
+	if m.blobsByExternalID != nil {
+		if b, ok := m.blobsByExternalID[externalID]; ok {
+			return b, nil
+		}
+		return nil, os.ErrNotExist
+	}
+	return m.data, m.err
+}
 
 // ReadStream mirrors Read's error contract for the streaming path: m.err (if set)
 // is returned as-is (tests set it to port.ErrInvalidKey / os.ErrNotExist / a generic
 // error to drive the handler's 400/404/500 mapping), else m.data is served over a
 // bytes reader.
-func (m *mockStorage) ReadStream(_ string) (io.ReadCloser, int64, error) {
+func (m *mockStorage) ReadStream(externalID string) (io.ReadCloser, int64, error) {
+	if m.blobsByExternalID != nil {
+		if b, ok := m.blobsByExternalID[externalID]; ok {
+			return io.NopCloser(bytes.NewReader(b)), int64(len(b)), nil
+		}
+		return nil, 0, os.ErrNotExist
+	}
 	if m.err != nil {
 		return nil, 0, m.err
 	}

--- a/internal/adapter/inbound/http/public_handler_test.go
+++ b/internal/adapter/inbound/http/public_handler_test.go
@@ -39,6 +39,7 @@ type mockDocRepo struct {
 	lastUpdateVersion     int
 
 	// Captured args from Create / UpdateFile content_metadata params (US1+).
+	lastCreateDoc                 model.Document
 	lastCreateContentMetadata     model.ContentMetadata
 	lastUpdateFileContentMetadata model.ContentMetadata
 
@@ -65,6 +66,7 @@ func (m *mockDocRepo) FindByExternalIDAndBucket(_ context.Context, _ string, _ u
 	return model.Document{}, model.ErrDocumentNotFound
 }
 func (m *mockDocRepo) Create(_ context.Context, doc model.Document, contentMetadata model.ContentMetadata) (uuid.UUID, error) {
+	m.lastCreateDoc = doc
 	m.lastCreateContentMetadata = contentMetadata
 	return doc.ID, m.createErr
 }

--- a/internal/adapter/inbound/http/public_handler_test.go
+++ b/internal/adapter/inbound/http/public_handler_test.go
@@ -142,13 +142,14 @@ func (m *mockAuth) CheckPrivilege(_ context.Context, actorID, privilege, authPol
 }
 
 type mockStorage struct {
-	data       []byte
-	err        error
-	saveErr    error
-	saved      []byte // captures the last Save/stage payload (replace-path rejection tests)
-	stages     []*httpMockStage
-	streamBody io.ReadCloser // if set, ReadStream returns this (to inject a mid-stream read failure)
-	streamSize int64         // Content-Length ReadStream reports when streamBody is set
+	data            []byte
+	err             error
+	saveErr         error
+	saved           []byte // captures the last Save/stage payload (replace-path rejection tests)
+	stages          []*httpMockStage
+	readStreamCalls int
+	streamBody      io.ReadCloser // if set, ReadStream returns this (to inject a mid-stream read failure)
+	streamSize      int64         // Content-Length ReadStream reports when streamBody is set
 	// Per-blob data for batch tests; nil keeps the existing flat mock behavior.
 	blobsByExternalID map[string][]byte
 }
@@ -204,6 +205,7 @@ func (m *mockStorage) Read(externalID string) ([]byte, error) {
 // error to drive the handler's 400/404/500 mapping), else m.data is served over a
 // bytes reader.
 func (m *mockStorage) ReadStream(externalID string) (io.ReadCloser, int64, error) {
+	m.readStreamCalls++
 	if m.blobsByExternalID != nil {
 		if b, ok := m.blobsByExternalID[externalID]; ok {
 			return io.NopCloser(bytes.NewReader(b)), int64(len(b)), nil
@@ -294,6 +296,41 @@ func TestPublicHandler_Unauthorized(t *testing.T) {
 
 	if rr.Code != http.StatusForbidden {
 		t.Fatalf("status = %d, want 403", rr.Code)
+	}
+}
+
+func TestPublicHandler_NullAuthorizationDeniedBeforeAuthOrStorage(t *testing.T) {
+	docID := uuid.New()
+	auth := &mockAuth{result: model.AuthResult{Allowed: true}}
+	storage := &mockStorage{data: []byte("internal snapshot")}
+	h := &PublicHandler{
+		Repo: &mockDocRepo{doc: model.Document{
+			ID:              docID,
+			ExternalID:      "snapshot-hash",
+			AuthorizationID: uuid.Nil,
+		}},
+		Auth:    auth,
+		Storage: storage,
+		MaxAge:  86400,
+		Logger:  zap.NewNop(),
+	}
+
+	r := chi.NewRouter()
+	r.Get("/rest/storage/file/{id}", h.ServeDocument)
+
+	req := httptest.NewRequest(http.MethodGet, "/rest/storage/file/"+docID.String(), nil)
+	req = req.WithContext(context.WithValue(req.Context(), ctxKeyActorID, "actor-1"))
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", rr.Code)
+	}
+	if auth.calls != 0 {
+		t.Fatalf("auth-eval called %d times, want 0", auth.calls)
+	}
+	if storage.readStreamCalls != 0 {
+		t.Fatalf("storage read called %d times, want 0", storage.readStreamCalls)
 	}
 }
 

--- a/internal/adapter/inbound/http/router.go
+++ b/internal/adapter/inbound/http/router.go
@@ -67,6 +67,7 @@ func NewRouter(deps Deps) *chi.Mux {
 	r.Route("/internal", func(r chi.Router) {
 		r.Post("/file", deps.DocumentHandler.Create)
 		r.Post("/file/copy", deps.DocumentHandler.Copy)
+		r.Post("/file/content-batch", deps.DocumentHandler.ContentBatch)
 		r.Get("/file/{id}/meta", deps.DocumentHandler.GetMeta)
 		r.Get("/file/{id}/content", deps.DocumentHandler.GetContent)
 		// Content-addressed read by SHA3-256 hash (workspace#008); rationale on GetBlobContent.

--- a/internal/adapter/inbound/http/router_test.go
+++ b/internal/adapter/inbound/http/router_test.go
@@ -197,6 +197,30 @@ func TestRouter_InternalDeleteDocument(t *testing.T) {
 	}
 }
 
+// POST /internal/file/content-batch must be registered under the same internal
+// (no-auth) route group as the other /internal/file endpoints. A well-formed
+// batch resolves to 200 through the full router (global middleware + no actor
+// header), confirming the wiring — not just that the route exists.
+func TestRouter_InternalContentBatch(t *testing.T) {
+	r := testRouter()
+
+	body := `{"ids":["` + uuid.New().String() + `"]}`
+	req := httptest.NewRequest(http.MethodPost, "/internal/file/content-batch", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	if rr.Code == http.StatusNotFound || rr.Code == http.StatusMethodNotAllowed {
+		t.Fatalf("POST /internal/file/content-batch = %d, route not registered", rr.Code)
+	}
+	// testRouter seeds a doc + blob and no auth on /internal, so a well-formed
+	// batch returns 200 (the single seeded row resolves; the point is the
+	// internal middleware chain let it through without an actor header).
+	if rr.Code != http.StatusOK {
+		t.Errorf("POST /internal/file/content-batch = %d, want 200 (no-auth internal route)", rr.Code)
+	}
+}
+
 func TestRouter_InternalPatchDocument(t *testing.T) {
 	r := testRouter()
 

--- a/internal/adapter/outbound/alkemiodb/adapter.go
+++ b/internal/adapter/outbound/alkemiodb/adapter.go
@@ -88,9 +88,9 @@ func (a *Adapter) FindByExternalIDAndBucket(ctx context.Context, externalID stri
 
 // Create inserts a new document row, serializing contentMetadata into the
 // JSONB content_metadata column (see marshalContentMetadata for the shape
-// rules). A unique violation — another row already holds this content in the
-// bucket — surfaces as model.ErrDuplicateKey so the service can fall back to
-// its dedup path.
+// rules). Any unique violation surfaces as model.ErrDuplicateKey; the service
+// probes (externalID, bucket) once to distinguish a content winner from an
+// authorizationId/tagsetId conflict.
 func (a *Adapter) Create(ctx context.Context, doc model.Document, contentMetadata model.ContentMetadata) (uuid.UUID, error) {
 	raw, err := marshalContentMetadata(contentMetadata)
 	if err != nil {
@@ -119,16 +119,18 @@ func createDocumentParams(doc model.Document, raw []byte) queries.CreateDocument
 		CreatedBy:         uuidToPgxNullable(doc.CreatedBy),
 		TemporaryLocation: doc.TemporaryLocation,
 		StorageBucketId:   uuidToPgx(doc.StorageBucketID),
-		AuthorizationId:   uuidToPgx(doc.AuthorizationID),
-		TagsetId:          uuidToPgxNullable(doc.TagsetID),
-		CreatedDate:       timeToPgx(doc.CreatedDate),
-		UpdatedDate:       timeToPgx(doc.UpdatedDate),
-		ContentMetadata:   raw,
+		// uuid.Nil means the create caller intentionally omitted authorization.
+		// Persist SQL NULL: the FK cannot reference the all-zero UUID, while the
+		// UNIQUE column permits multiple NULL rows.
+		AuthorizationId: uuidToPgxNullableNil(doc.AuthorizationID),
+		TagsetId:        uuidToPgxNullable(doc.TagsetID),
+		CreatedDate:     timeToPgx(doc.CreatedDate),
+		UpdatedDate:     timeToPgx(doc.UpdatedDate),
+		ContentMetadata: raw,
 	}
 }
 
-// isUniqueViolation reports whether err is a Postgres unique-constraint violation — the
-// signal that another row already holds this content in the bucket (the dedup race).
+// isUniqueViolation reports whether err is any Postgres unique-constraint violation.
 func isUniqueViolation(err error) bool {
 	var pgErr *pgconn.PgError
 	return errors.As(err, &pgErr) && pgErr.Code == pgerrcode.UniqueViolation

--- a/internal/adapter/outbound/alkemiodb/adapter_mock_test.go
+++ b/internal/adapter/outbound/alkemiodb/adapter_mock_test.go
@@ -141,6 +141,19 @@ func TestMock_Create_Success(t *testing.T) {
 	}
 }
 
+func TestCreateDocumentParams_OmittedAuthorizationIsNull(t *testing.T) {
+	params := createDocumentParams(model.Document{AuthorizationID: uuid.Nil}, []byte(`{}`))
+	if params.AuthorizationId.Valid {
+		t.Fatalf("omitted authorization mapping = %+v, want SQL NULL", params.AuthorizationId)
+	}
+
+	authID := uuid.New()
+	params = createDocumentParams(model.Document{AuthorizationID: authID}, []byte(`{}`))
+	if !params.AuthorizationId.Valid || params.AuthorizationId.Bytes != authID {
+		t.Fatalf("real authorization mapping = %+v, want valid %s", params.AuthorizationId, authID)
+	}
+}
+
 func TestMock_UpdateFile_Success(t *testing.T) {
 	mock, err := pgxmock.NewPool()
 	if err != nil {

--- a/internal/adapter/outbound/alkemiodb/convert.go
+++ b/internal/adapter/outbound/alkemiodb/convert.go
@@ -50,6 +50,16 @@ func uuidToPgxNullable(id *uuid.UUID) pgtype.UUID {
 	return pgtype.UUID{Bytes: *id, Valid: true}
 }
 
+// uuidToPgxNullableNil maps uuid.Nil to SQL NULL and every real UUID to a
+// valid pgx UUID. Create and CreateWithOutbox both call createDocumentParams,
+// so this is the single nullable-authorization mapping for both write paths.
+func uuidToPgxNullableNil(id uuid.UUID) pgtype.UUID {
+	if id == uuid.Nil {
+		return pgtype.UUID{Valid: false}
+	}
+	return pgtype.UUID{Bytes: id, Valid: true}
+}
+
 func pgxToUUID(id pgtype.UUID) uuid.UUID {
 	if !id.Valid {
 		return uuid.Nil

--- a/internal/adapter/outbound/alkemiodb/convert_test.go
+++ b/internal/adapter/outbound/alkemiodb/convert_test.go
@@ -35,6 +35,21 @@ func TestUuidToPgxNullable_NonNil(t *testing.T) {
 	}
 }
 
+func TestUuidToPgxNullableNil_NilUUID(t *testing.T) {
+	pgxID := uuidToPgxNullableNil(uuid.Nil)
+	if pgxID.Valid {
+		t.Error("uuid.Nil must map to SQL NULL")
+	}
+}
+
+func TestUuidToPgxNullableNil_RealUUID(t *testing.T) {
+	id := uuid.New()
+	pgxID := uuidToPgxNullableNil(id)
+	if !pgxID.Valid || pgxID.Bytes != id {
+		t.Fatalf("real UUID mapping = %+v, want valid %s", pgxID, id)
+	}
+}
+
 func TestPgxToUUID_Valid(t *testing.T) {
 	id := uuid.New()
 	pgxID := pgtype.UUID{Bytes: id, Valid: true}

--- a/internal/adapter/outbound/alkemiodb/outbox.go
+++ b/internal/adapter/outbound/alkemiodb/outbox.go
@@ -16,8 +16,8 @@ import (
 // committed non-temporary file row carries its backup hint). After commit it emits a best-effort
 // NOTIFY so the backup worker wakes immediately — the durable table + the worker's poll floor
 // cover a lost NOTIFY. A unique violation on the document → model.ErrDuplicateKey with NO outbox
-// row written (a dedup hit means the content already exists and was already captured); the
-// service's dedup path re-queries the winner exactly as on the non-outbox path.
+// row written; the service performs the same one-shot content-winner/conflict classification as
+// on the non-outbox path.
 func (a *Adapter) CreateWithOutbox(ctx context.Context, doc model.Document, contentMetadata model.ContentMetadata, priority int16) (uuid.UUID, error) {
 	raw, err := marshalContentMetadata(contentMetadata)
 	if err != nil {

--- a/internal/adapter/outbound/alkemiodb/outbox.go
+++ b/internal/adapter/outbound/alkemiodb/outbox.go
@@ -162,7 +162,7 @@ func (a *Adapter) DeletePendingByHash(ctx context.Context, externalID string) (i
 // though: a persistently failing NOTIFY (e.g. a permissions issue) should be visible rather than
 // silently dropped.
 func (a *Adapter) notifyBackup(ctx context.Context) {
-	if _, err := a.pool.Exec(ctx, "NOTIFY file_backup_outbox"); err != nil {
+	if err := a.queries.NotifyBackupOutbox(ctx); err != nil {
 		a.logger.Warn("backup-outbox NOTIFY failed (best-effort; the consumer's poll floor still drains)",
 			zap.Error(err))
 	}

--- a/internal/adapter/outbound/alkemiodb/outbox_mock_test.go
+++ b/internal/adapter/outbound/alkemiodb/outbox_mock_test.go
@@ -64,6 +64,34 @@ func TestMock_CreateWithOutbox_Commits(t *testing.T) {
 	}
 }
 
+func TestMock_CreateWithOutbox_OmittedAuthorizationIsNull(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mock.Close()
+	docID := uuid.New()
+	doc := sampleDoc(docID)
+	doc.AuthorizationID = uuid.Nil
+
+	insertArgs := anyArgs(13)
+	insertArgs[8] = pgtype.UUID{Valid: false} // authorizationId
+	mock.ExpectBegin()
+	mock.ExpectQuery("INSERT INTO file").WithArgs(insertArgs...).
+		WillReturnRows(mock.NewRows([]string{"id"}).AddRow(pgtype.UUID{Bytes: docID, Valid: true}))
+	mock.ExpectExec("INSERT INTO file_backup_outbox").WithArgs(anyArgs(6)...).
+		WillReturnResult(pgxmock.NewResult("INSERT", 1))
+	mock.ExpectCommit()
+	mock.ExpectExec("NOTIFY file_backup_outbox").WillReturnResult(pgxmock.NewResult("NOTIFY", 0))
+
+	if _, err := New(mock).CreateWithOutbox(context.Background(), doc, model.ContentMetadata{}, 0); err != nil {
+		t.Fatalf("CreateWithOutbox: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+}
+
 // TestMock_CreateWithOutbox_DedupRollsBack: a unique violation on the document rolls the
 // transaction back (NO outbox row, NO NOTIFY) and surfaces model.ErrDuplicateKey so the
 // service's dedup path re-queries the winner.

--- a/internal/adapter/outbound/alkemiodb/queries/outbox.sql.go
+++ b/internal/adapter/outbound/alkemiodb/queries/outbox.sql.go
@@ -65,6 +65,17 @@ func (q *Queries) EnqueueBackupOutbox(ctx context.Context, arg EnqueueBackupOutb
 	return err
 }
 
+const notifyBackupOutbox = `-- name: NotifyBackupOutbox :exec
+NOTIFY file_backup_outbox
+`
+
+// Best-effort post-commit wake for the backup worker after an outbox row is recorded. A lost
+// NOTIFY is covered by the durable table + the worker's poll floor, so callers ignore the error.
+func (q *Queries) NotifyBackupOutbox(ctx context.Context) error {
+	_, err := q.db.Exec(ctx, notifyBackupOutbox)
+	return err
+}
+
 const pruneBackupOutboxDone = `-- name: PruneBackupOutboxDone :execrows
 DELETE FROM file_backup_outbox
 WHERE status = 'done' AND "createdDate" < $1

--- a/internal/domain/model/document.go
+++ b/internal/domain/model/document.go
@@ -78,8 +78,11 @@ type CreateDocumentInput struct {
 	CreatedBy         *uuid.UUID
 	TemporaryLocation bool
 	StorageBucketID   uuid.UUID
-	AuthorizationID   uuid.UUID
-	TagsetID          *uuid.UUID
+	// AuthorizationID is optional for internal create callers. uuid.Nil
+	// persists as SQL NULL; a real UUID references an authorization policy.
+	// CopyDocumentInput intentionally remains required.
+	AuthorizationID uuid.UUID
+	TagsetID        *uuid.UUID
 
 	// SkipDedup, when true, bypasses the per-bucket content-hash dedup
 	// lookup and forces a fresh row insert even if an existing row in the

--- a/internal/domain/model/errors.go
+++ b/internal/domain/model/errors.go
@@ -5,7 +5,7 @@ import "errors"
 // ErrDocumentNotFound is returned when a document cannot be found in the repository.
 var ErrDocumentNotFound = errors.New("document not found")
 
-// ErrDuplicateKey is returned when an insert would violate a unique constraint
-// (e.g., the unique index on file(externalID, storageBucketId)).
-// Service layer uses this to detect concurrent-creator races.
+// ErrDuplicateKey is returned when an insert would violate any file-table
+// unique constraint. The service disambiguates a dedup winner from an
+// authorizationId/tagsetId collision by probing (externalID, bucket).
 var ErrDuplicateKey = errors.New("duplicate key")

--- a/internal/domain/port/backup_outbox.go
+++ b/internal/domain/port/backup_outbox.go
@@ -17,8 +17,8 @@ import (
 // existing write path, never a behaviour change when disabled.
 type BackupOutboxRepo interface {
 	// CreateWithOutbox inserts a new document and enqueues its backup hint atomically.
-	// Returns model.ErrDuplicateKey on the dedup race (no outbox row written), exactly as
-	// DocumentRepo.Create does, so the service's dedup path is unchanged.
+	// Returns model.ErrDuplicateKey on any document unique violation (no outbox row written),
+	// exactly as DocumentRepo.Create does, so service classification is identical.
 	CreateWithOutbox(ctx context.Context, doc model.Document, contentMetadata model.ContentMetadata, priority int16) (uuid.UUID, error)
 	// UpdateFileWithOutbox replaces a document's content and enqueues a backup hint for the new
 	// content hash atomically, compare-and-set against expectedExternalID and expectedVersion. Same

--- a/internal/domain/service/file_service.go
+++ b/internal/domain/service/file_service.go
@@ -96,7 +96,8 @@ var (
 
 // writeCreate persists a new document — via the transactional outbox path (a backup-outbox row
 // in the same commit, FR-001) when the producer is on and the object is non-temporary, else the
-// original non-transactional Repo.Create. Both return model.ErrDuplicateKey on the dedup race.
+// original non-transactional Repo.Create. Both return model.ErrDuplicateKey on any unique
+// violation; insertDocument classifies it after the write.
 func (s *FileService) writeCreate(ctx context.Context, doc model.Document, meta model.ContentMetadata) error {
 	if s.Outbox != nil && !doc.TemporaryLocation {
 		_, err := s.Outbox.CreateWithOutbox(ctx, doc, meta, s.priorityForMime(doc.MimeType))
@@ -181,6 +182,12 @@ func (s *FileService) findDedupDocument(ctx context.Context, externalID string, 
 // destination bucket already has a row with the same externalID, return
 // it as-is with Reused=true, matching the CreateDocument contract.
 func (s *FileService) CopyDocument(ctx context.Context, sourceID uuid.UUID, input model.CopyDocumentInput) (*model.Document, error) {
+	// Copy always creates a policy-owned logical document. Only the internal
+	// create flow may deliberately omit authorization.
+	if input.AuthorizationID == uuid.Nil {
+		return nil, ErrInvalidAuthorizationID
+	}
+
 	source, err := s.Repo.GetByID(ctx, sourceID)
 	if err != nil {
 		// ErrDocumentNotFound surfaces as 404 in the handler.
@@ -329,20 +336,24 @@ func (s *FileService) insertDocument(ctx context.Context, input model.CreateDocu
 	}
 
 	if errors.Is(err, model.ErrDuplicateKey) {
-		// SkipDedup means the caller explicitly asked for a fresh row. If the
-		// schema enforces unique(externalID, storageBucketID), we can't honor
-		// that intent — surface as ErrConflict rather than masquerading as a
-		// dedup hit (which would silently corrupt placeholder flows).
+		// SkipDedup means the caller explicitly asked for a fresh row. Any
+		// uniqueness failure means that insert cannot be honored; never
+		// masquerade it as a dedup hit and corrupt placeholder flows.
 		if input.SkipDedup {
 			return nil, ErrConflict
 		}
-		// Default path: another concurrent creator won the race on the
-		// unique(externalID, storageBucketID) index. Re-query and return
-		// the winner with Reused=true.
+		// One probe disambiguates the constraint without depending on its
+		// database-generated name: a matching content row is a valid dedup
+		// winner; no match means another unique column collided.
 		raced, findErr := s.Repo.FindByExternalIDAndBucket(ctx, stored.ExternalID, input.StorageBucketID)
 		if findErr == nil {
 			raced.Reused = true
 			return &raced, nil
+		}
+		if errors.Is(findErr, model.ErrDocumentNotFound) {
+			// No content winner exists, so treat this as a non-dedup unique
+			// collision (normally authorizationId or tagsetId).
+			return nil, ErrConflict
 		}
 		s.Logger.Warn("dedup: unique violation but re-query failed",
 			zap.String("externalID", stored.ExternalID), zap.Error(findErr))
@@ -567,10 +578,12 @@ var (
 	// the actor the required privilege. An evaluation that could not run at
 	// all surfaces as a wrapped transport error instead.
 	ErrForbidden = errors.New("forbidden")
-	// ErrConflict covers both flavors of write conflict: an optimistic-lock
-	// version mismatch on metadata updates, and a content-hash collision
-	// when SkipDedup forbids reusing the existing row.
-	ErrConflict = errors.New("conflict: document was modified concurrently")
+	// ErrConflict covers optimistic-lock failures and unique-column collisions
+	// that cannot be satisfied as a valid dedup hit.
+	ErrConflict = errors.New("conflict")
+	// ErrInvalidAuthorizationID rejects copy requests without a real policy ID.
+	// Create may intentionally use uuid.Nil, which persists as SQL NULL.
+	ErrInvalidAuthorizationID = errors.New("authorization ID is required for copy")
 	// ErrPayloadTooLarge rejects an upload exceeding the bucket's maxFileSize
 	// policy (distinct from the transport-level ErrOverLimit cap).
 	ErrPayloadTooLarge = errors.New("payload too large")

--- a/internal/domain/service/file_service.go
+++ b/internal/domain/service/file_service.go
@@ -137,6 +137,76 @@ func (s *FileService) PruneBackupOutbox(ctx context.Context, retention time.Dura
 	return n, err
 }
 
+// BatchContentResult is one entry of a ReadContentBatch response, positionally
+// aligned with the requested id slice. Found reports whether the document's
+// content was retrieved: when true, Content + MimeType are populated; when
+// false, Err records the per-id reason (row missing, blob gone) without
+// failing the whole batch.
+type BatchContentResult struct {
+	ID       uuid.UUID
+	Found    bool
+	Content  []byte
+	MimeType string
+	Err      error
+}
+
+// ErrBatchContentLimit means the next blob would exceed the caller's aggregate
+// response budget. Callers can retry that item in a smaller batch.
+var ErrBatchContentLimit = errors.New("batch content limit exceeded")
+
+// ReadContentBatch resolves the content blob for each requested document id in
+// one call, preserving order (result[i] corresponds to ids[i], duplicates
+// included). maxTotalBytes bounds the raw content retained across successful
+// results; an item that would exceed the remaining budget is returned with
+// ErrBatchContentLimit.
+//
+// Failures are per-id and non-fatal: a missing row or a missing blob yields
+// Found=false with Err set for that position; the remaining ids still resolve.
+func (s *FileService) ReadContentBatch(ctx context.Context, ids []uuid.UUID, maxTotalBytes int64) []BatchContentResult {
+	results := make([]BatchContentResult, 0, len(ids))
+	remaining := maxTotalBytes
+	for _, id := range ids {
+		result := s.readOneContent(ctx, id, remaining)
+		if result.Found {
+			remaining -= int64(len(result.Content))
+		}
+		results = append(results, result)
+	}
+	return results
+}
+
+func (s *FileService) readOneContent(ctx context.Context, id uuid.UUID, remaining int64) BatchContentResult {
+	doc, err := s.Repo.GetByID(ctx, id)
+	if err != nil {
+		return BatchContentResult{ID: id, Found: false, Err: err}
+	}
+	if remaining <= 0 {
+		return BatchContentResult{ID: id, Found: false, Err: ErrBatchContentLimit}
+	}
+	rc, size, err := s.Storage.ReadStream(doc.ExternalID)
+	if err != nil {
+		return BatchContentResult{ID: id, Found: false, Err: fmt.Errorf("open file stream: %w", err)}
+	}
+	if size > remaining {
+		_ = rc.Close()
+		return BatchContentResult{ID: id, Found: false, Err: ErrBatchContentLimit}
+	}
+
+	content, readErr := io.ReadAll(io.LimitReader(rc, remaining+1))
+	closeErr := rc.Close()
+	switch {
+	case readErr != nil:
+		return BatchContentResult{ID: id, Found: false, Err: fmt.Errorf("read file stream: %w", readErr)}
+	case closeErr != nil:
+		return BatchContentResult{ID: id, Found: false, Err: fmt.Errorf("close file stream: %w", closeErr)}
+	case int64(len(content)) > remaining:
+		return BatchContentResult{ID: id, Found: false, Err: ErrBatchContentLimit}
+	case size >= 0 && int64(len(content)) != size:
+		return BatchContentResult{ID: id, Found: false, Err: fmt.Errorf("read file stream: expected %d bytes, got %d", size, len(content))}
+	}
+	return BatchContentResult{ID: id, Found: true, Content: content, MimeType: doc.MimeType}
+}
+
 // CreateDocument ingests a complete buffer through the streaming pipeline
 // (spec 020): stage → validate → publish. Kept for buffer-shaped callers;
 // the HTTP handler streams the request directly via StageUpload +

--- a/internal/domain/service/file_service.go
+++ b/internal/domain/service/file_service.go
@@ -140,8 +140,8 @@ func (s *FileService) PruneBackupOutbox(ctx context.Context, retention time.Dura
 // BatchContentResult is one entry of a ReadContentBatch response, positionally
 // aligned with the requested id slice. Found reports whether the document's
 // content was retrieved: when true, Content + MimeType are populated; when
-// false, Err records the per-id reason (row missing, blob gone) without
-// failing the whole batch.
+// false, Err records the per-id reason (row missing, blob gone, backend
+// failure, or response-budget exhaustion) without failing the whole batch.
 type BatchContentResult struct {
 	ID       uuid.UUID
 	Found    bool
@@ -160,8 +160,9 @@ var ErrBatchContentLimit = errors.New("batch content limit exceeded")
 // results; an item that would exceed the remaining budget is returned with
 // ErrBatchContentLimit.
 //
-// Failures are per-id and non-fatal: a missing row or a missing blob yields
-// Found=false with Err set for that position; the remaining ids still resolve.
+// Failures are per-id and non-fatal: missing rows, missing blobs, and backend
+// errors yield Found=false with Err set for that position; the remaining ids
+// still resolve.
 func (s *FileService) ReadContentBatch(ctx context.Context, ids []uuid.UUID, maxTotalBytes int64) []BatchContentResult {
 	results := make([]BatchContentResult, 0, len(ids))
 	remaining := maxTotalBytes

--- a/internal/domain/service/file_service_test.go
+++ b/internal/domain/service/file_service_test.go
@@ -43,6 +43,7 @@ type mockRepo struct {
 	countErr      error
 
 	// Captured args from Create / UpdateFile content_metadata params.
+	lastCreateDoc                 model.Document
 	lastCreateContentMetadata     model.ContentMetadata
 	lastUpdateFileContentMetadata model.ContentMetadata
 
@@ -92,6 +93,7 @@ func (m *mockRepo) FindByExternalIDAndBucket(_ context.Context, externalID strin
 }
 func (m *mockRepo) Create(_ context.Context, doc model.Document, contentMetadata model.ContentMetadata) (uuid.UUID, error) {
 	m.createCalls++
+	m.lastCreateDoc = doc
 	m.lastCreateContentMetadata = contentMetadata
 	if m.createErrOnce != nil && m.createCalls == 1 {
 		return uuid.Nil, m.createErrOnce
@@ -307,6 +309,29 @@ func TestCreateDocument_Happy(t *testing.T) {
 	}
 }
 
+func TestCreateDocument_OmittedAuthorizationPersistsNil(t *testing.T) {
+	repo := &mockRepo{}
+	svc := &FileService{
+		Logger:    nopLogger,
+		Repo:      repo,
+		Storage:   &mockStorage{},
+		Processor: &mockProcessor{},
+	}
+
+	doc, err := svc.CreateDocument(context.Background(), model.CreateDocumentInput{
+		DisplayName:     "snapshot.ybin",
+		StorageBucketID: uuid.New(),
+		// AuthorizationID intentionally omitted: internal snapshot rows are
+		// stored with SQL NULL authorization.
+	}, []byte("content"), "", nil, 0)
+	if err != nil {
+		t.Fatalf("CreateDocument: %v", err)
+	}
+	if doc.AuthorizationID != uuid.Nil || repo.lastCreateDoc.AuthorizationID != uuid.Nil {
+		t.Fatalf("authorization = response %s / repo %s, want uuid.Nil", doc.AuthorizationID, repo.lastCreateDoc.AuthorizationID)
+	}
+}
+
 // Dedup: same content in same bucket → existing row returned, Reused=true,
 // caller-supplied auth/tagset ignored.
 func TestCreateDocument_Dedup_SameContentSameBucket_ReturnsExisting(t *testing.T) {
@@ -385,9 +410,9 @@ func TestCreateDocument_Dedup_SameContentDifferentBucket_InsertsNew(t *testing.T
 	}
 }
 
-// Concurrent race: first Create fails with ErrDuplicateKey (other writer
-// won the race on unique(externalID, storageBucketID)). Service re-queries
-// and returns the winner with Reused=true.
+// Defensive content-winner classification: a schema variant reports
+// ErrDuplicateKey and the follow-up (externalID, bucket) probe finds the
+// concurrent row. The service returns that row with Reused=true.
 func TestCreateDocument_Dedup_CreateRace_ReturnsWinnerAsReused(t *testing.T) {
 	winnerID := uuid.New()
 	winnerAuth := uuid.New()
@@ -431,6 +456,53 @@ func TestCreateDocument_Dedup_CreateRace_ReturnsWinnerAsReused(t *testing.T) {
 	}
 	if doc.AuthorizationID != winnerAuth {
 		t.Errorf("AuthorizationID = %v, want winner %v", doc.AuthorizationID, winnerAuth)
+	}
+}
+
+func TestCreateDocument_DuplicateKeyWithoutContentWinnerReturnsConflict(t *testing.T) {
+	repo := &mockRepoRace{
+		find: func() (model.Document, error) {
+			return model.Document{}, model.ErrDocumentNotFound
+		},
+		createErr: model.ErrDuplicateKey,
+	}
+	svc := &FileService{Logger: nopLogger, Repo: repo, Storage: &mockStorage{}, Processor: &mockProcessor{}}
+
+	_, err := svc.CreateDocument(context.Background(), model.CreateDocumentInput{
+		DisplayName:     "snapshot.ybin",
+		StorageBucketID: uuid.New(),
+		AuthorizationID: uuid.New(),
+	}, []byte("content"), "", nil, 0)
+	if !errors.Is(err, ErrConflict) {
+		t.Fatalf("error = %v, want ErrConflict for authorizationId/tagsetId collision", err)
+	}
+}
+
+func TestCreateDocument_DuplicateKeyWinnerLookupFailurePropagates(t *testing.T) {
+	dbErr := errors.New("database unavailable")
+	call := 0
+	repo := &mockRepoRace{
+		find: func() (model.Document, error) {
+			call++
+			if call == 1 {
+				return model.Document{}, model.ErrDocumentNotFound
+			}
+			return model.Document{}, dbErr
+		},
+		createErr: model.ErrDuplicateKey,
+	}
+	svc := &FileService{Logger: nopLogger, Repo: repo, Storage: &mockStorage{}, Processor: &mockProcessor{}}
+
+	_, err := svc.CreateDocument(context.Background(), model.CreateDocumentInput{
+		DisplayName:     "snapshot.ybin",
+		StorageBucketID: uuid.New(),
+		AuthorizationID: uuid.New(),
+	}, []byte("content"), "", nil, 0)
+	if !errors.Is(err, dbErr) {
+		t.Fatalf("error = %v, want wrapped lookup failure", err)
+	}
+	if errors.Is(err, ErrConflict) {
+		t.Fatalf("transport failure must not be classified as a client conflict: %v", err)
 	}
 }
 
@@ -698,6 +770,22 @@ func TestCreateDocument_DBFails_DoesNotDeleteBlob(t *testing.T) {
 
 // CopyDocument: happy path. Source exists in bucket A; copy to bucket B
 // produces a fresh row with same content metadata, caller's auth/tagset.
+func TestCopyDocument_RequiresAuthorization(t *testing.T) {
+	repo := &mockRepo{}
+	svc := &FileService{Logger: nopLogger, Repo: repo}
+
+	_, err := svc.CopyDocument(context.Background(), uuid.New(), model.CopyDocumentInput{
+		DestinationBucketID: uuid.New(),
+		AuthorizationID:     uuid.Nil,
+	})
+	if !errors.Is(err, ErrInvalidAuthorizationID) {
+		t.Fatalf("error = %v, want ErrInvalidAuthorizationID", err)
+	}
+	if repo.createCalls != 0 {
+		t.Fatalf("copy with no authorization must not create a row; calls=%d", repo.createCalls)
+	}
+}
+
 func TestCopyDocument_Happy(t *testing.T) {
 	sourceID := uuid.New()
 	bucketA := uuid.New()

--- a/internal/domain/service/file_service_test.go
+++ b/internal/domain/service/file_service_test.go
@@ -26,8 +26,16 @@ func (f *faultyReadCloser) Close() error             { return nil }
 // --- Mocks ---
 
 type mockRepo struct {
-	doc           model.Document
-	getErr        error
+	doc    model.Document
+	getErr error
+
+	// docsByID, when non-nil, makes GetByID id-aware: it returns the mapped
+	// document for a known id and model.ErrDocumentNotFound for an unknown
+	// one. Used by the batched-read tests, which need several distinct rows in
+	// one call. When nil, GetByID falls back to the doc/getErr pair so existing
+	// single-document tests are unaffected.
+	docsByID map[uuid.UUID]model.Document
+
 	findDoc       *model.Document // nil means "not found"
 	findErr       error           // if set, overrides findDoc
 	findCalls     int
@@ -76,7 +84,13 @@ type mockRepo struct {
 // Ensure mockRepo implements the full interface at compile time.
 var _ port.DocumentRepo = (*mockRepo)(nil)
 
-func (m *mockRepo) GetByID(_ context.Context, _ uuid.UUID) (model.Document, error) {
+func (m *mockRepo) GetByID(_ context.Context, id uuid.UUID) (model.Document, error) {
+	if m.docsByID != nil {
+		if doc, ok := m.docsByID[id]; ok {
+			return doc, nil
+		}
+		return model.Document{}, model.ErrDocumentNotFound
+	}
 	return m.doc, m.getErr
 }
 func (m *mockRepo) FindByExternalIDAndBucket(_ context.Context, externalID string, storageBucketID uuid.UUID) (model.Document, error) {

--- a/internal/domain/service/read_content_batch_test.go
+++ b/internal/domain/service/read_content_batch_test.go
@@ -1,0 +1,239 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/alkem-io/file-service/internal/domain/model"
+)
+
+type batchReadCloser struct {
+	io.Reader
+	closeErr error
+}
+
+func (r *batchReadCloser) Close() error { return r.closeErr }
+
+func newBatchService(repo *mockRepo, storage *mockStorage) *FileService {
+	return &FileService{
+		Repo:    repo,
+		Storage: storage,
+		Logger:  nopLogger,
+	}
+}
+
+func TestReadContentBatch_ReturnsEachBlobInOrder(t *testing.T) {
+	a, b := uuid.New(), uuid.New()
+	repo := &mockRepo{docsByID: map[uuid.UUID]model.Document{
+		a: {ID: a, ExternalID: "ext-a", MimeType: "text/plain"},
+		b: {ID: b, ExternalID: "ext-b", MimeType: "application/octet-stream"},
+	}}
+	storage := &mockStorage{dataByID: map[string][]byte{
+		"ext-a": []byte("AAA"),
+		"ext-b": []byte("BBB"),
+	}}
+	svc := newBatchService(repo, storage)
+
+	results := svc.ReadContentBatch(context.Background(), []uuid.UUID{a, b}, 1024)
+
+	if len(results) != 2 {
+		t.Fatalf("len(results) = %d, want 2", len(results))
+	}
+	if results[0].ID != a || !results[0].Found || string(results[0].Content) != "AAA" || results[0].MimeType != "text/plain" {
+		t.Errorf("results[0] = %+v, want a/found/AAA/text-plain", results[0])
+	}
+	if results[1].ID != b || !results[1].Found || string(results[1].Content) != "BBB" || results[1].MimeType != "application/octet-stream" {
+		t.Errorf("results[1] = %+v, want b/found/BBB/octet-stream", results[1])
+	}
+}
+
+func TestReadContentBatch_UnknownDocumentNonFatal(t *testing.T) {
+	present, missing := uuid.New(), uuid.New()
+	repo := &mockRepo{docsByID: map[uuid.UUID]model.Document{
+		present: {ID: present, ExternalID: "ext", MimeType: "text/plain"},
+		// missing intentionally absent.
+	}}
+	storage := &mockStorage{dataByID: map[string][]byte{"ext": []byte("ok")}}
+	svc := newBatchService(repo, storage)
+
+	results := svc.ReadContentBatch(context.Background(), []uuid.UUID{present, missing}, 1024)
+
+	if len(results) != 2 {
+		t.Fatalf("len(results) = %d, want 2", len(results))
+	}
+	if !results[0].Found {
+		t.Errorf("results[0] (present) Found = false, want true")
+	}
+	if results[1].Found {
+		t.Errorf("results[1] (missing) Found = true, want false")
+	}
+	if results[1].Err == nil {
+		t.Errorf("results[1] (missing) Err = nil, want non-fatal not-found error")
+	}
+	if !errors.Is(results[1].Err, model.ErrDocumentNotFound) {
+		t.Errorf("results[1].Err = %v, want wraps ErrDocumentNotFound", results[1].Err)
+	}
+}
+
+func TestReadContentBatch_BlobReadErrorNonFatal(t *testing.T) {
+	id := uuid.New()
+	repo := &mockRepo{docsByID: map[uuid.UUID]model.Document{
+		id: {ID: id, ExternalID: "ext-gone", MimeType: "text/plain"},
+	}}
+	// dataByID is non-nil but doesn't contain "ext-gone" → Read returns readErr.
+	storage := &mockStorage{
+		dataByID: map[string][]byte{"other": []byte("x")},
+		readErr:  errors.New("blob not on storage"),
+	}
+	svc := newBatchService(repo, storage)
+
+	results := svc.ReadContentBatch(context.Background(), []uuid.UUID{id}, 1024)
+
+	if len(results) != 1 {
+		t.Fatalf("len(results) = %d, want 1", len(results))
+	}
+	if results[0].Found {
+		t.Errorf("Found = true, want false on storage read error")
+	}
+	if results[0].Err == nil {
+		t.Errorf("Err = nil, want the storage read error recorded")
+	}
+}
+
+func TestReadContentBatch_EmptyInput(t *testing.T) {
+	svc := newBatchService(&mockRepo{}, &mockStorage{})
+	results := svc.ReadContentBatch(context.Background(), nil, 1024)
+	if len(results) != 0 {
+		t.Fatalf("len(results) = %d, want 0", len(results))
+	}
+}
+
+func TestReadContentBatch_DuplicatesPreserved(t *testing.T) {
+	id := uuid.New()
+	repo := &mockRepo{docsByID: map[uuid.UUID]model.Document{
+		id: {ID: id, ExternalID: "ext", MimeType: "text/plain"},
+	}}
+	storage := &mockStorage{dataByID: map[string][]byte{"ext": []byte("dup")}}
+	svc := newBatchService(repo, storage)
+
+	results := svc.ReadContentBatch(context.Background(), []uuid.UUID{id, id, id}, 1024)
+
+	if len(results) != 3 {
+		t.Fatalf("len(results) = %d, want 3", len(results))
+	}
+	for i, r := range results {
+		if !r.Found || string(r.Content) != "dup" {
+			t.Errorf("results[%d] = %+v, want found/dup", i, r)
+		}
+	}
+}
+
+func TestReadContentBatch_EnforcesAggregateByteLimit(t *testing.T) {
+	first, second := uuid.New(), uuid.New()
+	repo := &mockRepo{docsByID: map[uuid.UUID]model.Document{
+		first:  {ID: first, ExternalID: "first", MimeType: "text/plain"},
+		second: {ID: second, ExternalID: "second", MimeType: "text/plain"},
+	}}
+	storage := &mockStorage{dataByID: map[string][]byte{
+		"first":  []byte("1234"),
+		"second": []byte("5678"),
+	}}
+
+	results := newBatchService(repo, storage).ReadContentBatch(
+		context.Background(), []uuid.UUID{first, second}, 5,
+	)
+
+	if len(results) != 2 || !results[0].Found {
+		t.Fatalf("results = %+v, want first item found", results)
+	}
+	if results[1].Found || !errors.Is(results[1].Err, ErrBatchContentLimit) {
+		t.Fatalf("second result = %+v, want non-fatal byte-limit miss", results[1])
+	}
+}
+
+func TestReadContentBatch_StreamFailuresArePerItem(t *testing.T) {
+	id := uuid.New()
+	repo := &mockRepo{docsByID: map[uuid.UUID]model.Document{
+		id: {ID: id, ExternalID: "blob", MimeType: "text/plain"},
+	}}
+
+	tests := []struct {
+		name    string
+		storage *mockStorage
+	}{
+		{
+			name:    "mid-stream read error",
+			storage: &mockStorage{streamBody: &faultyReadCloser{}, streamSize: 1},
+		},
+		{
+			name: "close error",
+			storage: &mockStorage{
+				streamBody: &batchReadCloser{
+					Reader:   bytes.NewReader([]byte("x")),
+					closeErr: errors.New("close failed"),
+				},
+				streamSize: 1,
+			},
+		},
+		{
+			name: "short read",
+			storage: &mockStorage{
+				streamBody: io.NopCloser(bytes.NewReader([]byte("abc"))),
+				streamSize: 5,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := newBatchService(repo, tt.storage).ReadContentBatch(
+				context.Background(), []uuid.UUID{id}, 10,
+			)[0]
+			if result.Found || result.Err == nil || len(result.Content) != 0 {
+				t.Fatalf("result = %+v, want non-fatal stream failure", result)
+			}
+		})
+	}
+}
+
+func TestReadContentBatch_RejectsStreamThatExceedsReportedBudget(t *testing.T) {
+	id := uuid.New()
+	repo := &mockRepo{docsByID: map[uuid.UUID]model.Document{
+		id: {ID: id, ExternalID: "blob", MimeType: "text/plain"},
+	}}
+	storage := &mockStorage{
+		streamBody: io.NopCloser(bytes.NewReader([]byte("1234"))),
+		streamSize: 1,
+	}
+
+	result := newBatchService(repo, storage).ReadContentBatch(
+		context.Background(), []uuid.UUID{id}, 3,
+	)[0]
+	if result.Found || !errors.Is(result.Err, ErrBatchContentLimit) {
+		t.Fatalf("result = %+v, want byte-limit miss", result)
+	}
+}
+
+func TestReadContentBatch_ZeroRemainingSkipsNextBlob(t *testing.T) {
+	first, second := uuid.New(), uuid.New()
+	repo := &mockRepo{docsByID: map[uuid.UUID]model.Document{
+		first:  {ID: first, ExternalID: "first", MimeType: "text/plain"},
+		second: {ID: second, ExternalID: "second", MimeType: "text/plain"},
+	}}
+	storage := &mockStorage{dataByID: map[string][]byte{
+		"first":  []byte("1234"),
+		"second": []byte("not read"),
+	}}
+
+	results := newBatchService(repo, storage).ReadContentBatch(
+		context.Background(), []uuid.UUID{first, second}, 4,
+	)
+	if !results[0].Found || results[1].Found || !errors.Is(results[1].Err, ErrBatchContentLimit) {
+		t.Fatalf("results = %+v, want first found and second limited", results)
+	}
+}

--- a/internal/domain/service/read_content_batch_test.go
+++ b/internal/domain/service/read_content_batch_test.go
@@ -237,3 +237,20 @@ func TestReadContentBatch_ZeroRemainingSkipsNextBlob(t *testing.T) {
 		t.Fatalf("results = %+v, want first found and second limited", results)
 	}
 }
+
+func TestReadContentBatch_ExhaustedBudgetStillReportsMissingDocument(t *testing.T) {
+	first, missing := uuid.New(), uuid.New()
+	repo := &mockRepo{docsByID: map[uuid.UUID]model.Document{
+		first: {ID: first, ExternalID: "first", MimeType: "text/plain"},
+		// missing intentionally absent: positional miss semantics still apply
+		// after an earlier item consumes the byte budget.
+	}}
+	storage := &mockStorage{dataByID: map[string][]byte{"first": []byte("full")}}
+
+	results := newBatchService(repo, storage).ReadContentBatch(
+		context.Background(), []uuid.UUID{first, missing}, 4,
+	)
+	if !results[0].Found || !errors.Is(results[1].Err, model.ErrDocumentNotFound) {
+		t.Fatalf("results = %+v, want first found and second document-not-found", results)
+	}
+}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,5 +1,39 @@
 components:
   schemas:
+    http.ContentBatchItem:
+      properties:
+        contentBase64:
+          type: string
+        error:
+          type: string
+        found:
+          type: boolean
+        id:
+          type: string
+        mimeType:
+          type: string
+      required:
+        - id
+        - found
+      type: object
+    http.ContentBatchRequest:
+      properties:
+        ids:
+          items:
+            type: string
+          type: array
+      required:
+        - ids
+      type: object
+    http.ContentBatchResponse:
+      properties:
+        items:
+          items:
+            $ref: '#/components/schemas/http.ContentBatchItem'
+          type: array
+      required:
+        - items
+      type: object
     http.CopyDocumentRequest:
       properties:
         authorizationId:
@@ -315,6 +349,40 @@ paths:
         Create handles POST /internal/file — streaming ingest (spec 020): the
         file part flows request → sniff → (transcode) → staged storage without
         whole-file buffering.
+      tags:
+        - /internal
+  /internal/file/content-batch:
+    post:
+      description: |-
+        ContentBatch handles POST /internal/file/content-batch. Results preserve
+        request order and report malformed ids and missing content per item.
+      operationId: DocumentHandler.ContentBatch
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/http.ContentBatchRequest'
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/http.ContentBatchResponse'
+          description: OK
+        "400":
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/http.errorResponse'
+          description: Bad Request
+        "413":
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/http.errorResponse'
+          description: Request Entity Too Large
+      summary: ContentBatch handles POST /internal/file/content-batch.
       tags:
         - /internal
   /internal/file/copy:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -358,7 +358,7 @@ paths:
           content:
             application/json; charset=utf-8:
               schema:
-                $ref: '#/components/schemas/skipDedup-requested-but-a-row-with-this-content-already-exists-in-the-destination-bucket'
+                $ref: '#/components/schemas/copy-conflicts-with-an-existing-row'
           description: Conflict
         "500":
           content:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,5 +1,11 @@
 components:
   schemas:
+    http.ContentBatchIDs:
+      items:
+        type: string
+      maxItems: 256
+      minItems: 1
+      type: array
     http.ContentBatchItem:
       properties:
         contentBase64:
@@ -19,9 +25,7 @@ components:
     http.ContentBatchRequest:
       properties:
         ids:
-          items:
-            type: string
-          type: array
+          $ref: '#/components/schemas/http.ContentBatchIDs'
       required:
         - ids
       type: object
@@ -87,8 +91,6 @@ components:
           type: string
         tagsetId:
           type: string
-      required:
-        - authorizationId
       type: object
     http.DocumentMetaResponse:
       properties:


### PR DESCRIPTION
## What

Rebuilds the file-service slice of `workspace#006-collab-content-unification` directly on current `develop` as the single aggregate PR needed by the 006 flow and the upcoming feature-013 fallout.

This PR supersedes the old stacked #49/#50/#52 history, but deliberately does **not** retain #49's retry/backoff implementation: that commit assumed a PostgreSQL post-unique-violation visibility window that is not present in this path, and the repository schema has no unique `(externalID, storageBucketId)` constraint.

The branch now has exactly three commits:

1. the corrected #50 behavior for nullable create authorization and precise duplicate classification;
2. the bounded `POST /internal/file/content-batch` endpoint, reconciled with current `develop` and #64's streaming storage contract.
3. a sqlc `:exec` regeneration for the existing backup-outbox NOTIFY query (mechanical generated-query alignment).

## Corrected create semantics

- Internal create may omit `authorizationId`; `uuid.Nil` is the domain sentinel and persists as SQL `NULL` through the shared `createDocumentParams` helper.
- The shared mapping covers both plain `Create` and transactional `CreateWithOutbox`.
- An explicitly supplied all-zero UUID is rejected as 400 rather than silently becoming NULL.
- Copy still requires a real authorization policy id; `uuid.Nil` is rejected as 400.
- After `ErrDuplicateKey`, one `(externalID, bucket)` probe classifies the result:
  - winner found → valid dedup reuse;
  - no winner → authorization/tagset unique collision → 409;
  - backend lookup failure → propagated, not misreported as conflict.
- No retry, sleep, or synthetic commit-visibility model remains.

## Batched content read

`POST /internal/file/content-batch`

```json
{ "ids": ["<uuid>", "<uuid>"] }
```

returns one positional item per requested id, preserving order and duplicates. Hits carry MIME + base64 content; malformed ids, absent rows/blobs, stream faults, and response-budget misses are per-item and do not abort the rest of a valid batch.

Operational bounds:

- 1–256 ids at runtime;
- 16 KiB request-body cap applied **before** JSON decoding;
- 32 MiB aggregate raw-content response budget;
- storage reads use `ReadStream`, with close errors, mid-stream faults, short reads, and incorrect size metadata treated as per-item failures;
- internal route, matching the existing no-auth internal file endpoints.

## Review fixes carried forward from #52

- request body is bounded before decode;
- storage-error logging is nil-safe;
- base64 decoding is asserted in tests;
- narrative comments/nitpicks were trimmed while retaining required Go docs;
- generated OpenAPI includes the endpoint and 413 response.

### Known apispec limitation

apispec v0.4.25 does not infer `minItems: 1` / `maxItems: 256` from the direct `len(body.Ids)` reject-and-return guards. `openapi.yaml` remains entirely generator-owned—no hand-edited constraints or generator-specific duct tape were added. Tracked upstream as [antst/go-apispec#69](https://github.com/antst/go-apispec/issues/69).

## Validation

- `make sqlc-generate` — idempotent
- `make openapi` — idempotent
- `make build-stub` / `make build` — green
- `make lint` — 0 issues
- `go vet ./...` — green
- `make test` (`-race`) — green, 78.6% overall
- `make test-vips` (`-race`) — green, 79.4% overall
- all new batch handler/service functions — 100% covered, including stream failure and limit branches

Supersedes #50, which is now closed after this rewritten head passed remote CI. #49 is also closed because its implementation is intentionally excluded.

Ref: `workspace#006-collab-content-unification`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an internal endpoint for retrieving multiple file contents in one request.
  * Responses preserve request order and duplicates, include MIME types and base64-encoded content, and report unavailable items individually.
  * Added request-size and batch-size limits with clear validation errors.

* **Bug Fixes**
  * Omitted authorization IDs are stored as null.
  * Invalid authorization IDs in copy requests now return a client error.
  * Documents without authorization are denied before content access.
  * Improved document conflict handling and error messages.

* **Documentation**
  * Updated the API specification for batch retrieval and copy conflict responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- pr-image-report:start -->
---
### 📦 PR image — test the current state of this PR

```bash
docker pull ghcr.io/alkem-io/file-service:pr-53
```

Current build: `ghcr.io/alkem-io/file-service:pr-53-12ebb0c` · `linux/amd64` + `linux/arm64` · index digest `sha256:3ae50fcff93f9555ad4595b8856a15a853c6827d40517454b26ea9cd00091bb2`
<!-- pr-image-report:end -->
