### PR TITLE
feat(008): backup-outbox producer counters + docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,7 +109,7 @@ Continuous-backup outbox producer (008-continuous-file-backup, **off by default*
 
 The `file_backup_outbox` **table DDL is a server-owned migration** — file-service does
 only the transactional DML (enqueue) and the prune; `db/schema/outbox.sql` is a sqlc
-codegen mirror. Producer activity is counted on `/debug/vars`:
+codegen mirror. Producer activity is counted on `/internal/debug/vars`:
 `file_backup_outbox_enqueued_total`, `file_backup_outbox_pruned_total`.
 
 ## Integration Context

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,20 @@ Service:
 - `PORT` — HTTP listen port (default 4003)
 - `DOCUMENT_MAX_AGE` — Cache-Control max-age in seconds (default 86400)
 
+Continuous-backup outbox producer (008-continuous-file-backup, **off by default**):
+- `FILE_BACKUP_OUTBOX_ENABLED` — when true, a committed non-temporary create/replace also
+  commits a `file_backup_outbox` row in the SAME transaction, then emits `NOTIFY
+  file_backup_outbox`. Off = the original non-transactional write paths, unchanged.
+- `FILE_BACKUP_HOT_MIME_PREFIXES` — CSV of MIME prefixes enqueued at hot priority=1
+  (default: office/OOXML, ODF, legacy Word/Excel/PowerPoint, Yjs).
+- `FILE_BACKUP_OUTBOX_DONE_RETENTION_HOURS` — retention for consumer-finished (`done`)
+  rows before the hourly prune drops them (default 24).
+
+The `file_backup_outbox` **table DDL is a server-owned migration** — file-service does
+only the transactional DML (enqueue) and the prune; `db/schema/outbox.sql` is a sqlc
+codegen mirror. Producer activity is counted on `/debug/vars`:
+`file_backup_outbox_enqueued_total`, `file_backup_outbox_pruned_total`.
+
 ## Integration Context
 
 - Auth checks on public endpoints via h2c HTTP/2 (preferred)

--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ make build
 | `AUTH_BREAKER_FAILURE_THRESHOLD` | `3` | Circuit breaker threshold (h2c) |
 | `AUTH_BREAKER_TIMEOUT_SECONDS` | `15` | Circuit breaker open duration |
 | `AUTH_BREAKER_HALF_OPEN_MAX_REQUESTS` | `2` | Half-open test requests |
+| `FILE_BACKUP_OUTBOX_ENABLED` | `false` | Turn the continuous-backup outbox producer on (see below) |
+| `FILE_BACKUP_HOT_MIME_PREFIXES` | office/ODF/Yjs prefixes | CSV of MIME prefixes enqueued at hot priority (=1) |
+| `FILE_BACKUP_OUTBOX_DONE_RETENTION_HOURS` | `24` | How long consumer-finished (`done`) outbox rows are kept before the prune drops them |
 
 ### NATS-specific (only when NATS transport is active)
 
@@ -81,6 +84,30 @@ make build
 | `NATS_SUBJECT` | `auth.evaluate` | Auth subject |
 | `NATS_RECONNECT_WAIT_MS` | `1000` | Initial reconnect delay |
 | `NATS_RECONNECT_MAX_WAIT_MS` | `30000` | Max reconnect delay |
+
+## Continuous-backup outbox producer (`FILE_BACKUP_OUTBOX_ENABLED`)
+
+Part of the cross-repo `008-continuous-file-backup` feature. **Off by default** — a
+pure opt-in that leaves the original write paths byte-for-byte unchanged.
+
+When enabled, every committed **non-temporary** document create / content-replace also
+commits a `file_backup_outbox` row **in the same transaction** as the `file` write (so
+there is never a committed file without its backup hint, and never an outbox row without
+a file). After the commit the service emits a best-effort `NOTIFY file_backup_outbox` to
+wake the downstream backup worker; the durable table plus the worker's poll floor cover a
+lost notification. Temporary-location objects, and the flag-off path, enqueue nothing.
+
+`FILE_BACKUP_HOT_MIME_PREFIXES` marks user-authored, non-reconstructable classes
+(office/OOXML, ODF, legacy Word/Excel/PowerPoint, Yjs) as priority `1` (hot) for the
+lowest effective RPO; everything else is priority `0`.
+
+**Table ownership:** the `file_backup_outbox` DDL is a **server-owned migration** — it is
+*not* created here. file-service only performs the transactional DML (enqueue) and an
+hourly prune of `done` rows older than `FILE_BACKUP_OUTBOX_DONE_RETENTION_HOURS`, keeping
+the shared outbox bounded. `db/schema/outbox.sql` is a sqlc codegen mirror only.
+
+Producer activity is counted on the expvar endpoint (`/debug/vars`):
+`file_backup_outbox_enqueued_total` and `file_backup_outbox_pruned_total`.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ lowest effective RPO; everything else is priority `0`.
 hourly prune of `done` rows older than `FILE_BACKUP_OUTBOX_DONE_RETENTION_HOURS`, keeping
 the shared outbox bounded. `db/schema/outbox.sql` is a sqlc codegen mirror only.
 
-Producer activity is counted on the expvar endpoint (`/debug/vars`):
+Producer activity is counted on the expvar endpoint (`/internal/debug/vars`):
 `file_backup_outbox_enqueued_total` and `file_backup_outbox_pruned_total`.
 
 ## Development

--- a/internal/domain/service/backup_outbox_test.go
+++ b/internal/domain/service/backup_outbox_test.go
@@ -74,6 +74,7 @@ func TestWriteCreateRouting(t *testing.T) {
 	t.Run("producer-on-nontemporary-uses-outbox-hot", func(t *testing.T) {
 		repo, ob := &mockRepo{}, &recordingOutbox{}
 		s := &FileService{Repo: repo, Outbox: ob, HotMimePrefixes: []string{"application/x-yjs"}, Logger: nopLogger}
+		before := backupOutboxEnqueued.Value()
 		_ = s.writeCreate(context.Background(), nonTemp, model.ContentMetadata{})
 		if ob.createCalls != 1 || repo.createCalls != 0 {
 			t.Fatalf("on: outbox=%d repo=%d (want outbox=1 repo=0)", ob.createCalls, repo.createCalls)
@@ -81,13 +82,20 @@ func TestWriteCreateRouting(t *testing.T) {
 		if ob.lastPriority != 1 {
 			t.Fatalf("a yjs object must enqueue hot priority=1, got %d", ob.lastPriority)
 		}
+		if got := backupOutboxEnqueued.Value() - before; got != 1 {
+			t.Fatalf("a committed enqueue must count once (T011): got +%d", got)
+		}
 	})
 	t.Run("producer-on-temporary-uses-repo", func(t *testing.T) {
 		repo, ob := &mockRepo{}, &recordingOutbox{}
 		s := &FileService{Repo: repo, Outbox: ob, Logger: nopLogger}
+		before := backupOutboxEnqueued.Value()
 		_ = s.writeCreate(context.Background(), temp, model.ContentMetadata{})
 		if repo.createCalls != 1 || ob.createCalls != 0 {
 			t.Fatalf("temporary must NOT enqueue: repo=%d outbox=%d", repo.createCalls, ob.createCalls)
+		}
+		if got := backupOutboxEnqueued.Value() - before; got != 0 {
+			t.Fatalf("temporary must NOT count an enqueue (T011): got +%d", got)
 		}
 	})
 }
@@ -105,9 +113,13 @@ func TestWriteReplaceRouting(t *testing.T) {
 	t.Run("producer-on-nontemporary-uses-outbox", func(t *testing.T) {
 		repo, ob := &mockRepo{}, &recordingOutbox{}
 		s := &FileService{Repo: repo, Outbox: ob, Logger: nopLogger}
+		before := backupOutboxEnqueued.Value()
 		_ = s.writeReplace(context.Background(), model.Document{}, uuid.New(), "h", "image/jpeg", 5, model.ContentMetadata{})
 		if ob.updateCalls != 1 || repo.updateFileCalls != 0 {
 			t.Fatalf("outbox=%d repo=%d (want outbox=1 repo=0)", ob.updateCalls, repo.updateFileCalls)
+		}
+		if got := backupOutboxEnqueued.Value() - before; got != 1 {
+			t.Fatalf("a committed replace-enqueue must count once (T011): got +%d", got)
 		}
 	})
 	t.Run("producer-on-temporary-uses-repo", func(t *testing.T) {

--- a/internal/domain/service/file_service.go
+++ b/internal/domain/service/file_service.go
@@ -10,6 +10,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"expvar"
 	"fmt"
 	"io"
 	"strings"
@@ -80,12 +81,25 @@ func (s *FileService) priorityForMime(mimeType string) int16 {
 	return 0
 }
 
+// Continuous-backup producer counters (008-continuous-file-backup T011), published on the
+// expvar endpoint (/debug/vars) alongside the other file-service metrics. They are declared
+// here in the domain core — not in the inbound HTTP metrics file with the rest — because their
+// increment sites are here, and the core must not import the inbound adapter (hexagonal
+// boundary). expvar.NewInt registers globally, so they still surface on the same endpoint.
+var (
+	backupOutboxEnqueued = expvar.NewInt("file_backup_outbox_enqueued_total")
+	backupOutboxPruned   = expvar.NewInt("file_backup_outbox_pruned_total")
+)
+
 // writeCreate persists a new document — via the transactional outbox path (a backup-outbox row
 // in the same commit, FR-001) when the producer is on and the object is non-temporary, else the
 // original non-transactional Repo.Create. Both return model.ErrDuplicateKey on the dedup race.
 func (s *FileService) writeCreate(ctx context.Context, doc model.Document, meta model.ContentMetadata) error {
 	if s.Outbox != nil && !doc.TemporaryLocation {
 		_, err := s.Outbox.CreateWithOutbox(ctx, doc, meta, s.priorityForMime(doc.MimeType))
+		if err == nil {
+			backupOutboxEnqueued.Add(1)
+		}
 		return err
 	}
 	_, err := s.Repo.Create(ctx, doc, meta)
@@ -97,7 +111,11 @@ func (s *FileService) writeCreate(ctx context.Context, doc model.Document, meta 
 // else the original Repo.UpdateFile. Same error semantics either way.
 func (s *FileService) writeReplace(ctx context.Context, doc model.Document, documentID uuid.UUID, externalID, mimeType string, size int, meta model.ContentMetadata) error {
 	if s.Outbox != nil && !doc.TemporaryLocation {
-		return s.Outbox.UpdateFileWithOutbox(ctx, documentID, externalID, mimeType, size, meta, s.priorityForMime(mimeType))
+		err := s.Outbox.UpdateFileWithOutbox(ctx, documentID, externalID, mimeType, size, meta, s.priorityForMime(mimeType))
+		if err == nil {
+			backupOutboxEnqueued.Add(1)
+		}
+		return err
 	}
 	return s.Repo.UpdateFile(ctx, documentID, externalID, mimeType, size, meta)
 }
@@ -108,7 +126,11 @@ func (s *FileService) PruneBackupOutbox(ctx context.Context, retention time.Dura
 	if s.Outbox == nil {
 		return 0, nil
 	}
-	return s.Outbox.PruneBackupOutbox(ctx, time.Now().Add(-retention))
+	n, err := s.Outbox.PruneBackupOutbox(ctx, time.Now().Add(-retention))
+	if err == nil && n > 0 {
+		backupOutboxPruned.Add(n)
+	}
+	return n, err
 }
 
 // ServeResult contains file content and metadata for serving.

--- a/internal/domain/service/file_service.go
+++ b/internal/domain/service/file_service.go
@@ -82,7 +82,7 @@ func (s *FileService) priorityForMime(mimeType string) int16 {
 }
 
 // Continuous-backup producer counters (008-continuous-file-backup T011), published on the
-// expvar endpoint (/debug/vars) alongside the other file-service metrics. They are declared
+// expvar endpoint (/internal/debug/vars) alongside the other file-service metrics. They are declared
 // here in the domain core — not in the inbound HTTP metrics file with the rest — because their
 // increment sites are here, and the core must not import the inbound adapter (hexagonal
 // boundary). expvar.NewInt registers globally, so they still surface on the same endpoint.


### PR DESCRIPTION
Polish slice of the cross-repo `008-continuous-file-backup` feature (`workspace#008-continuous-file-backup`). The transactional outbox producer itself landed in #56; this closes the two remaining polish tasks.

## T011 — producer observability
- Publish two expvar counters on the existing `/debug/vars` endpoint:
  - `file_backup_outbox_enqueued_total` — incremented on each committed enqueue (non-temporary create/replace, flag on).
  - `file_backup_outbox_pruned_total` — incremented per row dropped by the hourly `done` prune.
- Declared in the domain core (`internal/domain/service/file_service.go`) next to their increment sites, because the core must not import the inbound HTTP adapter that declares the rest of the metrics (hexagonal boundary). `expvar.NewInt` registers globally, so they still surface on the same endpoint as `mime_repair_total`, `ingest_outcomes_total`, etc.
- Counters only increment on a successful commit (a dedup `ErrDuplicateKey` writes no row → not counted).
- Existing routing tests extended with `+1` / `+0` enqueue-count deltas.

No Prometheus registry exists in this repo; expvar is its established metrics facility, so counters (not log lines) are the consistent choice.

## T012 — docs
- `README.md`: new "Continuous-backup outbox producer" section + the three `FILE_BACKUP_*` env vars in the Optional config table.
- `CLAUDE.md`: producer note in the Configuration section.
- Both state: default **off**, transactional DML + prune only, and that the `file_backup_outbox` **table DDL is a server-owned migration** (file-service does not create it).

## Surface / gates
- **No API surface change** — outbox is internal DML; `openapi.yaml` untouched.
- `golangci-lint run` → 0 issues.
- `go test -race ./...` → all pass (service pkg 90.6%, total 77.0%).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional continuous backup outbox producer (off by default), including hot priority handling, best-effort notification, and retention/pruning of completed backup entries.
* **Documentation**
  * Documented new environment variables and the expected continuous outbox behavior in setup/configuration guides.
* **Observability**
  * Added runtime metrics for backup outbox enqueueing and pruning activity.
* **Tests**
  * Extended routing tests to verify enqueue behavior for non-temporary files and ensure temporary files do not enqueue outbox entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- pr-image-report:start -->
---
### 📦 PR image — test the current state of this PR

```bash
docker pull ghcr.io/alkem-io/file-service:pr-58
```

Current build: `ghcr.io/alkem-io/file-service:pr-58-36e45df` · `linux/amd64` + `linux/arm64` · index digest `sha256:bc4829634de428e113ceddf6a81cb0a807262e1c055c7cdce805b27a353c49b7`
<!-- pr-image-report:end -->
