### PR TITLE
feat(008): outbox hygiene — drop pending outbox rows for a blob file-service deletes

### DIFF
--- a/db/queries/outbox.sql
+++ b/db/queries/outbox.sql
@@ -13,3 +13,12 @@ VALUES ($1, $2, $3, $4, $5, $6);
 -- record. Only 'done' is pruned — pending/in_progress/dead_letter/skipped are retained.
 DELETE FROM file_backup_outbox
 WHERE status = 'done' AND "createdDate" < $1;
+
+-- name: DeleteBackupOutboxPendingByHash :execrows
+-- Orphan hygiene: when the LAST file row referencing a blob is deleted and the blob itself is
+-- removed (refcount→0), any still-pending outbox row for that hash points at bytes that no
+-- longer exist — the consumer's fetch could only ever 404. file-service is the one deleting the
+-- blob, so it removes the dead hint too (master-of-orphans). in_progress rows are left to the
+-- consumer's own 404→skip backstop; done/skipped/dead_letter are history, untouched.
+DELETE FROM file_backup_outbox
+WHERE "externalID" = $1 AND status = 'pending';

--- a/db/queries/outbox.sql
+++ b/db/queries/outbox.sql
@@ -14,11 +14,14 @@ VALUES ($1, $2, $3, $4, $5, $6);
 DELETE FROM file_backup_outbox
 WHERE status = 'done' AND "createdDate" < $1;
 
--- name: DeleteBackupOutboxPendingByHash :execrows
--- Orphan hygiene: when the LAST file row referencing a blob is deleted and the blob itself is
--- removed (refcount→0), any still-pending outbox row for that hash points at bytes that no
--- longer exist — the consumer's fetch could only ever 404. file-service is the one deleting the
--- blob, so it removes the dead hint too (master-of-orphans). in_progress rows are left to the
--- consumer's own 404→skip backstop; done/skipped/dead_letter are history, untouched.
+-- name: DeleteBackupOutboxPendingForFile :execrows
+-- Orphan hygiene: when THIS file's last-referenced blob is removed (refcount→0), its own
+-- still-pending outbox hint points at bytes that no longer exist — the consumer's fetch could
+-- only ever 404. file-service is the one deleting the blob, so it removes the dead hint too
+-- (master-of-orphans). Scoped to ("fileId", "externalID"), NOT to the hash alone: content
+-- addressing means a concurrent re-upload of the SAME content enqueues a pending row with the
+-- SAME "externalID" but a DIFFERENT "fileId" — deleting by hash would silently wipe that live
+-- document's backup hint. in_progress rows are left to the consumer's own 404→skip backstop;
+-- done/skipped/dead_letter are history, untouched.
 DELETE FROM file_backup_outbox
-WHERE "externalID" = $1 AND status = 'pending';
+WHERE "fileId" = $1 AND "externalID" = $2 AND status = 'pending';

--- a/db/queries/outbox.sql
+++ b/db/queries/outbox.sql
@@ -18,10 +18,15 @@ WHERE status = 'done' AND "createdDate" < $1;
 -- Orphan hygiene: when THIS file's last-referenced blob is removed (refcount→0), its own
 -- still-pending outbox hint points at bytes that no longer exist — the consumer's fetch could
 -- only ever 404. file-service is the one deleting the blob, so it removes the dead hint too
--- (master-of-orphans). Scoped to ("fileId", "externalID"), NOT to the hash alone: content
--- addressing means a concurrent re-upload of the SAME content enqueues a pending row with the
--- SAME "externalID" but a DIFFERENT "fileId" — deleting by hash would silently wipe that live
--- document's backup hint. in_progress rows are left to the consumer's own 404→skip backstop;
--- done/skipped/dead_letter are history, untouched.
-DELETE FROM file_backup_outbox
-WHERE "fileId" = $1 AND "externalID" = $2 AND status = 'pending';
+-- (master-of-orphans). Scoped to ("fileId", "externalID"), NOT the hash alone: a concurrent
+-- re-upload of the SAME content by ANOTHER document enqueues a row with the same "externalID" but
+-- a different "fileId", which must not be touched. The NOT EXISTS guard closes the remaining
+-- same-document race: if a concurrent replace put THIS document's content BACK to this hash
+-- (A→B→A) and re-enqueued it, the file row again ties $1 to $2, so its still-live hint is spared —
+-- the row is deleted ONLY when this document genuinely no longer references this content, checked
+-- atomically against the owner's own `file` table (producer-side; not the consumer's wall).
+-- in_progress rows are left to the consumer's own 404→skip backstop; done/skipped/dead_letter
+-- are history, untouched.
+DELETE FROM file_backup_outbox o
+WHERE o."fileId" = $1 AND o."externalID" = $2 AND o.status = 'pending'
+  AND NOT EXISTS (SELECT 1 FROM file f WHERE f.id = $1 AND f."externalID" = $2);

--- a/internal/adapter/outbound/alkemiodb/outbox.go
+++ b/internal/adapter/outbound/alkemiodb/outbox.go
@@ -104,9 +104,12 @@ func (a *Adapter) PruneBackupOutbox(ctx context.Context, olderThan time.Time) (i
 	return a.queries.PruneBackupOutboxDone(ctx, timeToPgx(olderThan))
 }
 
-// DeletePendingByHash implements port.BackupOutboxRepo (orphan hygiene — see the query doc).
-func (a *Adapter) DeletePendingByHash(ctx context.Context, externalID string) (int64, error) {
-	return a.queries.DeleteBackupOutboxPendingByHash(ctx, externalID)
+// DeletePendingForFile implements port.BackupOutboxRepo (orphan hygiene — see the query doc).
+func (a *Adapter) DeletePendingForFile(ctx context.Context, fileID uuid.UUID, externalID string) (int64, error) {
+	return a.queries.DeleteBackupOutboxPendingForFile(ctx, queries.DeleteBackupOutboxPendingForFileParams{
+		FileId:     uuidToPgx(fileID),
+		ExternalID: externalID,
+	})
 }
 
 // notifyBackup emits NOTIFY on the backup channel after a committed enqueue. Best-effort — it

--- a/internal/adapter/outbound/alkemiodb/outbox.go
+++ b/internal/adapter/outbound/alkemiodb/outbox.go
@@ -104,6 +104,11 @@ func (a *Adapter) PruneBackupOutbox(ctx context.Context, olderThan time.Time) (i
 	return a.queries.PruneBackupOutboxDone(ctx, timeToPgx(olderThan))
 }
 
+// DeletePendingByHash implements port.BackupOutboxRepo (orphan hygiene — see the query doc).
+func (a *Adapter) DeletePendingByHash(ctx context.Context, externalID string) (int64, error) {
+	return a.queries.DeleteBackupOutboxPendingByHash(ctx, externalID)
+}
+
 // notifyBackup emits NOTIFY on the backup channel after a committed enqueue. Best-effort — it
 // must NOT fail a committed write, and the durable table + the consumer's poll floor guarantee
 // progress if the notification is lost — so the error is not propagated. It IS logged at warn,

--- a/internal/adapter/outbound/alkemiodb/outbox_mock_test.go
+++ b/internal/adapter/outbound/alkemiodb/outbox_mock_test.go
@@ -209,3 +209,28 @@ func TestMock_PruneBackupOutbox(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+// TestMock_DeletePendingForFile_ScopedAndGuarded: the orphan-hygiene delete is scoped to
+// (fileId, externalID) AND carries the NOT EXISTS guard (a live file row still tying them spares
+// the hint — the same-doc A→B→A replace-back race). Asserts the scope args and that the guard is
+// present; dropping "AND NOT EXISTS" would reopen the race and fail this test.
+func TestMock_DeletePendingForFile_ScopedAndGuarded(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mock.Close()
+	fileID := uuid.New()
+
+	mock.ExpectExec("AND NOT EXISTS").
+		WithArgs(pgtype.UUID{Bytes: fileID, Valid: true}, "somehash").
+		WillReturnResult(pgxmock.NewResult("DELETE", 1))
+
+	n, err := New(mock).DeletePendingForFile(context.Background(), fileID, "somehash")
+	if err != nil || n != 1 {
+		t.Fatalf("DeletePendingForFile = %d, %v (want 1, nil)", n, err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+}

--- a/internal/adapter/outbound/alkemiodb/outbox_mock_test.go
+++ b/internal/adapter/outbound/alkemiodb/outbox_mock_test.go
@@ -222,7 +222,10 @@ func TestMock_DeletePendingForFile_ScopedAndGuarded(t *testing.T) {
 	defer mock.Close()
 	fileID := uuid.New()
 
-	mock.ExpectExec("AND NOT EXISTS").
+	// Match the FULL guard predicate, not just the "AND NOT EXISTS" marker, so a subtly-wrong
+	// guard (dropped externalID predicate, or wrong subquery table) also fails — not only a total
+	// removal of the clause.
+	mock.ExpectExec(`NOT EXISTS \(SELECT 1 FROM file f WHERE f\.id = \$1 AND f\."externalID" = \$2\)`).
 		WithArgs(pgtype.UUID{Bytes: fileID, Valid: true}, "somehash").
 		WillReturnResult(pgxmock.NewResult("DELETE", 1))
 

--- a/internal/adapter/outbound/alkemiodb/outbox_mock_test.go
+++ b/internal/adapter/outbound/alkemiodb/outbox_mock_test.go
@@ -210,10 +210,12 @@ func TestMock_PruneBackupOutbox(t *testing.T) {
 	}
 }
 
-// TestMock_DeletePendingForFile_ScopedAndGuarded: the orphan-hygiene delete is scoped to
-// (fileId, externalID) AND carries the NOT EXISTS guard (a live file row still tying them spares
-// the hint — the same-doc A→B→A replace-back race). Asserts the scope args and that the guard is
-// present; dropping "AND NOT EXISTS" would reopen the race and fail this test.
+// TestMock_DeletePendingForFile_ScopedAndGuarded: the orphan-hygiene delete must carry BOTH the
+// outer scope (fileId + externalID + status='pending') AND the NOT EXISTS guard — either half
+// dropped is a real regression (drop the scope → a whole-table mass over-delete; drop the guard →
+// reopen the same-doc A→B→A live-hint deletion). pgxmock does unanchored substring matching, so
+// the regex asserts the FULL statement structure (both halves) — a subtly-wrong query fails, not
+// only a total removal of the clause.
 func TestMock_DeletePendingForFile_ScopedAndGuarded(t *testing.T) {
 	mock, err := pgxmock.NewPool()
 	if err != nil {
@@ -222,10 +224,7 @@ func TestMock_DeletePendingForFile_ScopedAndGuarded(t *testing.T) {
 	defer mock.Close()
 	fileID := uuid.New()
 
-	// Match the FULL guard predicate, not just the "AND NOT EXISTS" marker, so a subtly-wrong
-	// guard (dropped externalID predicate, or wrong subquery table) also fails — not only a total
-	// removal of the clause.
-	mock.ExpectExec(`NOT EXISTS \(SELECT 1 FROM file f WHERE f\.id = \$1 AND f\."externalID" = \$2\)`).
+	mock.ExpectExec(`(?s)DELETE FROM file_backup_outbox o\s+WHERE o\."fileId" = \$1 AND o\."externalID" = \$2 AND o\.status = 'pending'\s+AND NOT EXISTS \(SELECT 1 FROM file f WHERE f\.id = \$1 AND f\."externalID" = \$2\)`).
 		WithArgs(pgtype.UUID{Bytes: fileID, Valid: true}, "somehash").
 		WillReturnResult(pgxmock.NewResult("DELETE", 1))
 

--- a/internal/adapter/outbound/alkemiodb/queries/outbox.sql.go
+++ b/internal/adapter/outbound/alkemiodb/queries/outbox.sql.go
@@ -11,6 +11,24 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const deleteBackupOutboxPendingByHash = `-- name: DeleteBackupOutboxPendingByHash :execrows
+DELETE FROM file_backup_outbox
+WHERE "externalID" = $1 AND status = 'pending'
+`
+
+// Orphan hygiene: when the LAST file row referencing a blob is deleted and the blob itself is
+// removed (refcount→0), any still-pending outbox row for that hash points at bytes that no
+// longer exist — the consumer's fetch could only ever 404. file-service is the one deleting the
+// blob, so it removes the dead hint too (master-of-orphans). in_progress rows are left to the
+// consumer's own 404→skip backstop; done/skipped/dead_letter are history, untouched.
+func (q *Queries) DeleteBackupOutboxPendingByHash(ctx context.Context, externalid string) (int64, error) {
+	result, err := q.db.Exec(ctx, deleteBackupOutboxPendingByHash, externalid)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const enqueueBackupOutbox = `-- name: EnqueueBackupOutbox :exec
 
 INSERT INTO file_backup_outbox ("fileId", "externalID", priority, "createdBy", "createdDate", size)

--- a/internal/adapter/outbound/alkemiodb/queries/outbox.sql.go
+++ b/internal/adapter/outbound/alkemiodb/queries/outbox.sql.go
@@ -11,18 +11,26 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
-const deleteBackupOutboxPendingByHash = `-- name: DeleteBackupOutboxPendingByHash :execrows
+const deleteBackupOutboxPendingForFile = `-- name: DeleteBackupOutboxPendingForFile :execrows
 DELETE FROM file_backup_outbox
-WHERE "externalID" = $1 AND status = 'pending'
+WHERE "fileId" = $1 AND "externalID" = $2 AND status = 'pending'
 `
 
-// Orphan hygiene: when the LAST file row referencing a blob is deleted and the blob itself is
-// removed (refcount→0), any still-pending outbox row for that hash points at bytes that no
-// longer exist — the consumer's fetch could only ever 404. file-service is the one deleting the
-// blob, so it removes the dead hint too (master-of-orphans). in_progress rows are left to the
-// consumer's own 404→skip backstop; done/skipped/dead_letter are history, untouched.
-func (q *Queries) DeleteBackupOutboxPendingByHash(ctx context.Context, externalid string) (int64, error) {
-	result, err := q.db.Exec(ctx, deleteBackupOutboxPendingByHash, externalid)
+type DeleteBackupOutboxPendingForFileParams struct {
+	FileId     pgtype.UUID `json:"fileId"`
+	ExternalID string      `json:"externalID"`
+}
+
+// Orphan hygiene: when THIS file's last-referenced blob is removed (refcount→0), its own
+// still-pending outbox hint points at bytes that no longer exist — the consumer's fetch could
+// only ever 404. file-service is the one deleting the blob, so it removes the dead hint too
+// (master-of-orphans). Scoped to ("fileId", "externalID"), NOT to the hash alone: content
+// addressing means a concurrent re-upload of the SAME content enqueues a pending row with the
+// SAME "externalID" but a DIFFERENT "fileId" — deleting by hash would silently wipe that live
+// document's backup hint. in_progress rows are left to the consumer's own 404→skip backstop;
+// done/skipped/dead_letter are history, untouched.
+func (q *Queries) DeleteBackupOutboxPendingForFile(ctx context.Context, arg DeleteBackupOutboxPendingForFileParams) (int64, error) {
+	result, err := q.db.Exec(ctx, deleteBackupOutboxPendingForFile, arg.FileId, arg.ExternalID)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/adapter/outbound/alkemiodb/queries/outbox.sql.go
+++ b/internal/adapter/outbound/alkemiodb/queries/outbox.sql.go
@@ -12,8 +12,9 @@ import (
 )
 
 const deleteBackupOutboxPendingForFile = `-- name: DeleteBackupOutboxPendingForFile :execrows
-DELETE FROM file_backup_outbox
-WHERE "fileId" = $1 AND "externalID" = $2 AND status = 'pending'
+DELETE FROM file_backup_outbox o
+WHERE o."fileId" = $1 AND o."externalID" = $2 AND o.status = 'pending'
+  AND NOT EXISTS (SELECT 1 FROM file f WHERE f.id = $1 AND f."externalID" = $2)
 `
 
 type DeleteBackupOutboxPendingForFileParams struct {
@@ -24,11 +25,15 @@ type DeleteBackupOutboxPendingForFileParams struct {
 // Orphan hygiene: when THIS file's last-referenced blob is removed (refcount→0), its own
 // still-pending outbox hint points at bytes that no longer exist — the consumer's fetch could
 // only ever 404. file-service is the one deleting the blob, so it removes the dead hint too
-// (master-of-orphans). Scoped to ("fileId", "externalID"), NOT to the hash alone: content
-// addressing means a concurrent re-upload of the SAME content enqueues a pending row with the
-// SAME "externalID" but a DIFFERENT "fileId" — deleting by hash would silently wipe that live
-// document's backup hint. in_progress rows are left to the consumer's own 404→skip backstop;
-// done/skipped/dead_letter are history, untouched.
+// (master-of-orphans). Scoped to ("fileId", "externalID"), NOT the hash alone: a concurrent
+// re-upload of the SAME content by ANOTHER document enqueues a row with the same "externalID" but
+// a different "fileId", which must not be touched. The NOT EXISTS guard closes the remaining
+// same-document race: if a concurrent replace put THIS document's content BACK to this hash
+// (A→B→A) and re-enqueued it, the file row again ties $1 to $2, so its still-live hint is spared —
+// the row is deleted ONLY when this document genuinely no longer references this content, checked
+// atomically against the owner's own `file` table (producer-side; not the consumer's wall).
+// in_progress rows are left to the consumer's own 404→skip backstop; done/skipped/dead_letter
+// are history, untouched.
 func (q *Queries) DeleteBackupOutboxPendingForFile(ctx context.Context, arg DeleteBackupOutboxPendingForFileParams) (int64, error) {
 	result, err := q.db.Exec(ctx, deleteBackupOutboxPendingForFile, arg.FileId, arg.ExternalID)
 	if err != nil {

--- a/internal/domain/port/backup_outbox.go
+++ b/internal/domain/port/backup_outbox.go
@@ -26,9 +26,11 @@ type BackupOutboxRepo interface {
 	// PruneBackupOutbox drops `done` outbox rows older than the cutoff, keeping the shared
 	// outbox bounded (SC-008); returns the number pruned.
 	PruneBackupOutbox(ctx context.Context, olderThan time.Time) (int64, error)
-	// DeletePendingByHash drops still-pending outbox rows for a content hash whose blob
-	// file-service has just deleted (refcount→0) — orphan hygiene at the owner: those rows
-	// point at bytes that no longer exist, so the consumer's fetch could only 404. Returns
-	// the number removed.
-	DeletePendingByHash(ctx context.Context, externalID string) (int64, error)
+	// DeletePendingForFile drops THIS file's still-pending outbox row(s) for a content hash
+	// whose blob file-service has just deleted (refcount→0) — orphan hygiene at the owner: the
+	// row points at bytes that no longer exist, so the consumer's fetch could only 404. Scoped
+	// to (fileID, externalID), never the hash alone: a concurrent re-upload of the same content
+	// enqueues a pending row with the same externalID but a different fileID, and must not be
+	// touched. Returns the number removed.
+	DeletePendingForFile(ctx context.Context, fileID uuid.UUID, externalID string) (int64, error)
 }

--- a/internal/domain/port/backup_outbox.go
+++ b/internal/domain/port/backup_outbox.go
@@ -26,4 +26,9 @@ type BackupOutboxRepo interface {
 	// PruneBackupOutbox drops `done` outbox rows older than the cutoff, keeping the shared
 	// outbox bounded (SC-008); returns the number pruned.
 	PruneBackupOutbox(ctx context.Context, olderThan time.Time) (int64, error)
+	// DeletePendingByHash drops still-pending outbox rows for a content hash whose blob
+	// file-service has just deleted (refcount→0) — orphan hygiene at the owner: those rows
+	// point at bytes that no longer exist, so the consumer's fetch could only 404. Returns
+	// the number removed.
+	DeletePendingByHash(ctx context.Context, externalID string) (int64, error)
 }

--- a/internal/domain/port/backup_outbox.go
+++ b/internal/domain/port/backup_outbox.go
@@ -28,9 +28,12 @@ type BackupOutboxRepo interface {
 	PruneBackupOutbox(ctx context.Context, olderThan time.Time) (int64, error)
 	// DeletePendingForFile drops THIS file's still-pending outbox row(s) for a content hash
 	// whose blob file-service has just deleted (refcount→0) — orphan hygiene at the owner: the
-	// row points at bytes that no longer exist, so the consumer's fetch could only 404. Scoped
-	// to (fileID, externalID), never the hash alone: a concurrent re-upload of the same content
-	// enqueues a pending row with the same externalID but a different fileID, and must not be
-	// touched. Returns the number removed.
+	// row points at bytes that no longer exist, so the consumer's fetch could only 404. The delete
+	// MUST NOT remove a live hint: it is scoped to (fileID, externalID) — never the hash alone, or
+	// a concurrent re-upload by ANOTHER document (same externalID, different fileID) would be wiped
+	// — AND guarded so it fires only when this document no longer references this content, sparing
+	// a same-document A→B→A replace that re-enqueued the same hash. Both are load-bearing: an
+	// implementation that drops either scope silently reintroduces a live-hint deletion (a DR gap).
+	// Returns the number removed.
 	DeletePendingForFile(ctx context.Context, fileID uuid.UUID, externalID string) (int64, error)
 }

--- a/internal/domain/service/backup_outbox_test.go
+++ b/internal/domain/service/backup_outbox_test.go
@@ -71,15 +71,6 @@ func TestCleanupOrphanedBlobDropsPendingOutboxRows(t *testing.T) {
 		t.Fatalf("orphan-hygiene counter must advance by the rows removed (2), got +%d", got)
 	}
 
-	// n==0 (nothing was pending for this file) must NOT move the counter (the n>0 guard).
-	zeroOutbox := &recordingOutbox{deletePendingN: 0}
-	sZero := &FileService{Storage: &mockStorage{data: []byte("x")}, Outbox: zeroOutbox, Logger: nopLogger}
-	before0 := backupOutboxOrphaned.Value()
-	sZero.cleanupOrphanedBlob(context.Background(), fileID, "somehash")
-	if got := backupOutboxOrphaned.Value() - before0; got != 0 {
-		t.Fatalf("no rows removed must not move the counter, got +%d", got)
-	}
-
 	// Producer OFF (nil Outbox): only the outbox step is skipped — the blob delete path is
 	// unchanged, so the blob must STILL be deleted (and no panic on the nil Outbox).
 	offStorage := &mockStorage{data: []byte("x")}
@@ -90,7 +81,9 @@ func TestCleanupOrphanedBlobDropsPendingOutboxRows(t *testing.T) {
 	}
 
 	// Blob delete FAILING must keep the row: while the blob exists it is still backable.
-	failing := &recordingOutbox{deletePendingN: 1}
+	// (deletePendingN is irrelevant here — DeletePendingForFile is never reached; the failed
+	// Storage.Delete returns first, which is exactly what the assertion below proves.)
+	failing := &recordingOutbox{}
 	sFail := &FileService{
 		Storage: &mockStorage{data: []byte("x"), deleteErr: errors.New("fs busy")},
 		Outbox:  failing,

--- a/internal/domain/service/backup_outbox_test.go
+++ b/internal/domain/service/backup_outbox_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -14,9 +15,10 @@ import (
 // recordingOutbox is a fake BackupOutboxRepo that records which transactional path ran and the
 // priority it was handed — enough to assert the flag/temporary-location routing (FR-001).
 type recordingOutbox struct {
-	createCalls  int
-	updateCalls  int
-	lastPriority int16
+	createCalls      int
+	updateCalls      int
+	lastPriority     int16
+	deletePendingFor []string // hashes passed to DeletePendingByHash (orphan hygiene)
 }
 
 var _ port.BackupOutboxRepo = (*recordingOutbox)(nil)
@@ -35,6 +37,43 @@ func (o *recordingOutbox) UpdateFileWithOutbox(_ context.Context, _ uuid.UUID, _
 
 func (o *recordingOutbox) PruneBackupOutbox(_ context.Context, _ time.Time) (int64, error) {
 	return 0, nil
+}
+
+func (o *recordingOutbox) DeletePendingByHash(_ context.Context, externalID string) (int64, error) {
+	o.deletePendingFor = append(o.deletePendingFor, externalID)
+	return 1, nil
+}
+
+// When the last reference to a blob is deleted and the producer is ON, the pending outbox rows
+// for that hash are dropped too (orphan hygiene: the bytes are gone, a fetch could only 404).
+// With the producer OFF (Outbox nil) the cleanup is skipped entirely — no behaviour change.
+func TestCleanupOrphanedBlobDropsPendingOutboxRows(t *testing.T) {
+	outbox := &recordingOutbox{}
+	s := &FileService{
+		Storage: &mockStorage{data: []byte("x")},
+		Outbox:  outbox,
+		Logger:  nopLogger,
+	}
+	s.cleanupOrphanedBlob(context.Background(), "somehash")
+	if len(outbox.deletePendingFor) != 1 || outbox.deletePendingFor[0] != "somehash" {
+		t.Fatalf("pending outbox rows not dropped for the deleted blob: %v", outbox.deletePendingFor)
+	}
+
+	// Producer off → nil Outbox → no panic, no cleanup call.
+	sOff := &FileService{Storage: &mockStorage{data: []byte("x")}, Logger: nopLogger}
+	sOff.cleanupOrphanedBlob(context.Background(), "somehash")
+
+	// Blob delete FAILING must keep the rows: while the blob exists they are still backable.
+	failing := &recordingOutbox{}
+	sFail := &FileService{
+		Storage: &mockStorage{data: []byte("x"), deleteErr: errors.New("fs busy")},
+		Outbox:  failing,
+		Logger:  nopLogger,
+	}
+	sFail.cleanupOrphanedBlob(context.Background(), "somehash")
+	if len(failing.deletePendingFor) != 0 {
+		t.Fatal("outbox rows must be kept when the blob delete failed (blob still backable)")
+	}
 }
 
 func TestPriorityForMime(t *testing.T) {

--- a/internal/domain/service/backup_outbox_test.go
+++ b/internal/domain/service/backup_outbox_test.go
@@ -18,7 +18,7 @@ type recordingOutbox struct {
 	createCalls      int
 	updateCalls      int
 	lastPriority     int16
-	deletePendingFor []string // hashes passed to DeletePendingByHash (orphan hygiene)
+	deletePendingFor []string // "<fileID>|<hash>" passed to DeletePendingForFile (orphan hygiene)
 }
 
 var _ port.BackupOutboxRepo = (*recordingOutbox)(nil)
@@ -39,40 +39,48 @@ func (o *recordingOutbox) PruneBackupOutbox(_ context.Context, _ time.Time) (int
 	return 0, nil
 }
 
-func (o *recordingOutbox) DeletePendingByHash(_ context.Context, externalID string) (int64, error) {
-	o.deletePendingFor = append(o.deletePendingFor, externalID)
+func (o *recordingOutbox) DeletePendingForFile(_ context.Context, fileID uuid.UUID, externalID string) (int64, error) {
+	o.deletePendingFor = append(o.deletePendingFor, fileID.String()+"|"+externalID)
 	return 1, nil
 }
 
-// When the last reference to a blob is deleted and the producer is ON, the pending outbox rows
-// for that hash are dropped too (orphan hygiene: the bytes are gone, a fetch could only 404).
-// With the producer OFF (Outbox nil) the cleanup is skipped entirely — no behaviour change.
+// When the last reference to a blob is deleted and the producer is ON, THIS file's pending outbox
+// hint is dropped too (orphan hygiene: the bytes are gone, a fetch could only 404) — scoped to
+// (fileID, externalID), never the hash alone. With the producer OFF (Outbox nil) the cleanup is
+// skipped entirely — no behaviour change.
 func TestCleanupOrphanedBlobDropsPendingOutboxRows(t *testing.T) {
+	fileID := uuid.New()
 	outbox := &recordingOutbox{}
 	s := &FileService{
 		Storage: &mockStorage{data: []byte("x")},
 		Outbox:  outbox,
 		Logger:  nopLogger,
 	}
-	s.cleanupOrphanedBlob(context.Background(), "somehash")
-	if len(outbox.deletePendingFor) != 1 || outbox.deletePendingFor[0] != "somehash" {
-		t.Fatalf("pending outbox rows not dropped for the deleted blob: %v", outbox.deletePendingFor)
+	before := backupOutboxOrphaned.Value()
+	s.cleanupOrphanedBlob(context.Background(), fileID, "somehash")
+	want := fileID.String() + "|somehash"
+	if len(outbox.deletePendingFor) != 1 || outbox.deletePendingFor[0] != want {
+		t.Fatalf("pending outbox row not dropped for (fileID, hash): got %v, want [%q]", outbox.deletePendingFor, want)
+	}
+	// The orphan-hygiene deletion is metered (parity with enqueue/prune).
+	if got := backupOutboxOrphaned.Value() - before; got != 1 {
+		t.Fatalf("orphan-hygiene delete must count once, got +%d", got)
 	}
 
 	// Producer off → nil Outbox → no panic, no cleanup call.
 	sOff := &FileService{Storage: &mockStorage{data: []byte("x")}, Logger: nopLogger}
-	sOff.cleanupOrphanedBlob(context.Background(), "somehash")
+	sOff.cleanupOrphanedBlob(context.Background(), fileID, "somehash")
 
-	// Blob delete FAILING must keep the rows: while the blob exists they are still backable.
+	// Blob delete FAILING must keep the row: while the blob exists it is still backable.
 	failing := &recordingOutbox{}
 	sFail := &FileService{
 		Storage: &mockStorage{data: []byte("x"), deleteErr: errors.New("fs busy")},
 		Outbox:  failing,
 		Logger:  nopLogger,
 	}
-	sFail.cleanupOrphanedBlob(context.Background(), "somehash")
+	sFail.cleanupOrphanedBlob(context.Background(), fileID, "somehash")
 	if len(failing.deletePendingFor) != 0 {
-		t.Fatal("outbox rows must be kept when the blob delete failed (blob still backable)")
+		t.Fatal("outbox row must be kept when the blob delete failed (blob still backable)")
 	}
 }
 

--- a/internal/domain/service/backup_outbox_test.go
+++ b/internal/domain/service/backup_outbox_test.go
@@ -19,6 +19,7 @@ type recordingOutbox struct {
 	updateCalls      int
 	lastPriority     int16
 	deletePendingFor []string // "<fileID>|<hash>" passed to DeletePendingForFile (orphan hygiene)
+	deletePendingN   int64    // rows DeletePendingForFile reports removed (drives the counter assertion)
 }
 
 var _ port.BackupOutboxRepo = (*recordingOutbox)(nil)
@@ -41,38 +42,55 @@ func (o *recordingOutbox) PruneBackupOutbox(_ context.Context, _ time.Time) (int
 
 func (o *recordingOutbox) DeletePendingForFile(_ context.Context, fileID uuid.UUID, externalID string) (int64, error) {
 	o.deletePendingFor = append(o.deletePendingFor, fileID.String()+"|"+externalID)
-	return 1, nil
+	return o.deletePendingN, nil
 }
 
 // When the last reference to a blob is deleted and the producer is ON, THIS file's pending outbox
 // hint is dropped too (orphan hygiene: the bytes are gone, a fetch could only 404) — scoped to
-// (fileID, externalID), never the hash alone. With the producer OFF (Outbox nil) the cleanup is
-// skipped entirely — no behaviour change.
+// (fileID, externalID), never the hash alone. With the producer OFF (Outbox nil) only the outbox
+// step is skipped — the blob delete itself is unchanged.
 func TestCleanupOrphanedBlobDropsPendingOutboxRows(t *testing.T) {
 	fileID := uuid.New()
-	outbox := &recordingOutbox{}
-	s := &FileService{
-		Storage: &mockStorage{data: []byte("x")},
-		Outbox:  outbox,
-		Logger:  nopLogger,
-	}
+
+	// Producer ON: the blob is deleted AND this file's pending hint is dropped, scoped to
+	// (fileID, hash). The counter advances by the exact number of rows removed (n=2, not a
+	// hardcoded 1) so an Add(n)→Add(1) regression is caught.
+	outbox := &recordingOutbox{deletePendingN: 2}
+	storage := &mockStorage{data: []byte("x")}
+	s := &FileService{Storage: storage, Outbox: outbox, Logger: nopLogger}
 	before := backupOutboxOrphaned.Value()
 	s.cleanupOrphanedBlob(context.Background(), fileID, "somehash")
+	if !storage.deleted {
+		t.Fatal("the orphaned blob must be deleted")
+	}
 	want := fileID.String() + "|somehash"
 	if len(outbox.deletePendingFor) != 1 || outbox.deletePendingFor[0] != want {
 		t.Fatalf("pending outbox row not dropped for (fileID, hash): got %v, want [%q]", outbox.deletePendingFor, want)
 	}
-	// The orphan-hygiene deletion is metered (parity with enqueue/prune).
-	if got := backupOutboxOrphaned.Value() - before; got != 1 {
-		t.Fatalf("orphan-hygiene delete must count once, got +%d", got)
+	if got := backupOutboxOrphaned.Value() - before; got != 2 {
+		t.Fatalf("orphan-hygiene counter must advance by the rows removed (2), got +%d", got)
 	}
 
-	// Producer off → nil Outbox → no panic, no cleanup call.
-	sOff := &FileService{Storage: &mockStorage{data: []byte("x")}, Logger: nopLogger}
+	// n==0 (nothing was pending for this file) must NOT move the counter (the n>0 guard).
+	zeroOutbox := &recordingOutbox{deletePendingN: 0}
+	sZero := &FileService{Storage: &mockStorage{data: []byte("x")}, Outbox: zeroOutbox, Logger: nopLogger}
+	before0 := backupOutboxOrphaned.Value()
+	sZero.cleanupOrphanedBlob(context.Background(), fileID, "somehash")
+	if got := backupOutboxOrphaned.Value() - before0; got != 0 {
+		t.Fatalf("no rows removed must not move the counter, got +%d", got)
+	}
+
+	// Producer OFF (nil Outbox): only the outbox step is skipped — the blob delete path is
+	// unchanged, so the blob must STILL be deleted (and no panic on the nil Outbox).
+	offStorage := &mockStorage{data: []byte("x")}
+	sOff := &FileService{Storage: offStorage, Logger: nopLogger}
 	sOff.cleanupOrphanedBlob(context.Background(), fileID, "somehash")
+	if !offStorage.deleted {
+		t.Fatal("producer off must not change the blob-delete path — the blob must still be deleted")
+	}
 
 	// Blob delete FAILING must keep the row: while the blob exists it is still backable.
-	failing := &recordingOutbox{}
+	failing := &recordingOutbox{deletePendingN: 1}
 	sFail := &FileService{
 		Storage: &mockStorage{data: []byte("x"), deleteErr: errors.New("fs busy")},
 		Outbox:  failing,

--- a/internal/domain/service/file_service.go
+++ b/internal/domain/service/file_service.go
@@ -421,14 +421,16 @@ func (s *FileService) DeleteDocument(ctx context.Context, documentID uuid.UUID) 
 // when the backup producer is on — drops fileID's own still-pending backup-outbox hint for that
 // hash: it points at bytes that no longer exist, so the consumer's fetch could only ever 404
 // (file-service is the master of orphans; it deleted the blob, so it removes the dead hint too).
-// The outbox delete is scoped to (fileID, externalID), NOT the hash alone: under content
-// addressing a concurrent re-upload of the same content enqueues a pending row with the same
-// externalID but a different fileID, and deleting by hash would silently wipe that live
-// document's backup hint — an unrecoverable DR gap. The benign corollary: if two documents in
-// different buckets shared a hash and are deleted at different times, the earlier one's pending
-// row is left behind when the blob finally goes (count→0) — the consumer's 404→skip backstop
-// retires it. That one wasted fetch is the deliberate trade for never touching a live row.
-// Both steps are best-effort warn-only
+// The outbox delete is scoped to (fileID, externalID) AND guarded by a NOT EXISTS check (see the
+// query) so it can only ever remove a genuinely-dead hint: (a) the hash scope alone is unsafe —
+// a concurrent re-upload of the same content by ANOTHER document shares the externalID, so a
+// by-hash delete would wipe that live document's hint; (b) the NOT EXISTS closes the same-document
+// race — if a concurrent replace put THIS document's content back to this hash (A→B→A) and
+// re-enqueued it, the file row again ties fileID→externalID, so its live hint is spared. Two
+// residuals remain, both benign: a sibling document that shared the hash and was deleted earlier
+// leaves a stale pending row until the consumer's 404→skip backstop retires it; and the
+// pre-existing count→Storage.Delete blob-GC race (a concurrent create re-referencing the blob) is
+// unchanged by this PR — its proper fix is atomic GC. Both steps are best-effort warn-only
 // cleanup: a leftover blob is GC-able, and a leftover pending row is caught by the consumer's
 // own 404→skip backstop. The outbox cleanup runs only after a successful blob delete — while the
 // blob exists, pending rows are still backable.

--- a/internal/domain/service/file_service.go
+++ b/internal/domain/service/file_service.go
@@ -421,16 +421,14 @@ func (s *FileService) DeleteDocument(ctx context.Context, documentID uuid.UUID) 
 // when the backup producer is on — drops fileID's own still-pending backup-outbox hint for that
 // hash: it points at bytes that no longer exist, so the consumer's fetch could only ever 404
 // (file-service is the master of orphans; it deleted the blob, so it removes the dead hint too).
-// The outbox delete is scoped to (fileID, externalID) AND guarded by a NOT EXISTS check (see the
-// query) so it can only ever remove a genuinely-dead hint: (a) the hash scope alone is unsafe —
-// a concurrent re-upload of the same content by ANOTHER document shares the externalID, so a
-// by-hash delete would wipe that live document's hint; (b) the NOT EXISTS closes the same-document
-// race — if a concurrent replace put THIS document's content back to this hash (A→B→A) and
-// re-enqueued it, the file row again ties fileID→externalID, so its live hint is spared. Two
-// residuals remain, both benign: a sibling document that shared the hash and was deleted earlier
-// leaves a stale pending row until the consumer's 404→skip backstop retires it; and the
-// pre-existing count→Storage.Delete blob-GC race (a concurrent create re-referencing the blob) is
-// unchanged by this PR — its proper fix is atomic GC. Both steps are best-effort warn-only
+// The outbox delete is scoped and guarded so it can only ever remove a genuinely-dead hint —
+// never another document's, nor a live re-enqueued one from a same-document A→B→A replace (the
+// exact (fileID, externalID) + NOT EXISTS predicate and its reasoning live in the query,
+// DeleteBackupOutboxPendingForFile). Two residuals remain, both benign: a sibling document that
+// shared the hash and was deleted earlier leaves a stale pending row until the consumer's 404→skip
+// backstop retires it; and the pre-existing count→Storage.Delete blob-GC race (a concurrent create
+// re-referencing the blob) is unchanged by this PR — its proper fix is atomic GC. Both steps are
+// best-effort warn-only
 // cleanup: a leftover blob is GC-able, and a leftover pending row is caught by the consumer's
 // own 404→skip backstop. The outbox cleanup runs only after a successful blob delete — while the
 // blob exists, pending rows are still backable.

--- a/internal/domain/service/file_service.go
+++ b/internal/domain/service/file_service.go
@@ -428,10 +428,9 @@ func (s *FileService) DeleteDocument(ctx context.Context, documentID uuid.UUID) 
 // shared the hash and was deleted earlier leaves a stale pending row until the consumer's 404→skip
 // backstop retires it; and the pre-existing count→Storage.Delete blob-GC race (a concurrent create
 // re-referencing the blob) is unchanged by this PR — its proper fix is atomic GC. Both steps are
-// best-effort warn-only
-// cleanup: a leftover blob is GC-able, and a leftover pending row is caught by the consumer's
-// own 404→skip backstop. The outbox cleanup runs only after a successful blob delete — while the
-// blob exists, pending rows are still backable.
+// best-effort warn-only cleanup: a leftover blob is GC-able, and a leftover pending row is caught
+// by the consumer's own 404→skip backstop. The outbox cleanup runs only after a successful blob
+// delete — while the blob exists, pending rows are still backable.
 func (s *FileService) cleanupOrphanedBlob(ctx context.Context, fileID uuid.UUID, externalID string) {
 	if err := s.Storage.Delete(externalID); err != nil {
 		s.Logger.Warn("cleanup: failed to delete orphaned file", zap.String("externalID", externalID), zap.Error(err))

--- a/internal/domain/service/file_service.go
+++ b/internal/domain/service/file_service.go
@@ -424,7 +424,11 @@ func (s *FileService) DeleteDocument(ctx context.Context, documentID uuid.UUID) 
 // The outbox delete is scoped to (fileID, externalID), NOT the hash alone: under content
 // addressing a concurrent re-upload of the same content enqueues a pending row with the same
 // externalID but a different fileID, and deleting by hash would silently wipe that live
-// document's backup hint — an unrecoverable DR gap. Both steps are best-effort warn-only
+// document's backup hint — an unrecoverable DR gap. The benign corollary: if two documents in
+// different buckets shared a hash and are deleted at different times, the earlier one's pending
+// row is left behind when the blob finally goes (count→0) — the consumer's 404→skip backstop
+// retires it. That one wasted fetch is the deliberate trade for never touching a live row.
+// Both steps are best-effort warn-only
 // cleanup: a leftover blob is GC-able, and a leftover pending row is caught by the consumer's
 // own 404→skip backstop. The outbox cleanup runs only after a successful blob delete — while the
 // blob exists, pending rows are still backable.

--- a/internal/domain/service/file_service.go
+++ b/internal/domain/service/file_service.go
@@ -407,12 +407,34 @@ func (s *FileService) DeleteDocument(ctx context.Context, documentID uuid.UUID) 
 
 	// Only delete file if no remaining documents reference it
 	if count == 0 {
-		if delErr := s.Storage.Delete(deleted.ExternalID); delErr != nil {
-			s.Logger.Warn("cleanup: failed to delete orphaned file", zap.String("externalID", deleted.ExternalID), zap.Error(delErr))
-		}
+		s.cleanupOrphanedBlob(ctx, deleted.ExternalID)
 	}
 
 	return &deleted, nil
+}
+
+// cleanupOrphanedBlob removes a blob whose last referencing file row is gone (refcount→0), and —
+// when the backup producer is on — drops any still-pending backup-outbox rows for that hash:
+// they point at bytes that no longer exist, so the consumer's fetch could only ever 404
+// (file-service is the master of orphans; it deleted the blob, so it removes the dead hint too).
+// Both steps are best-effort warn-only cleanup: a leftover blob is GC-able, and a leftover
+// pending row is caught by the consumer's own 404→skip backstop. The outbox cleanup runs only
+// after a successful blob delete — while the blob exists, pending rows are still backable.
+func (s *FileService) cleanupOrphanedBlob(ctx context.Context, externalID string) {
+	if err := s.Storage.Delete(externalID); err != nil {
+		s.Logger.Warn("cleanup: failed to delete orphaned file", zap.String("externalID", externalID), zap.Error(err))
+		return
+	}
+	if s.Outbox == nil {
+		return
+	}
+	if n, err := s.Outbox.DeletePendingByHash(ctx, externalID); err != nil {
+		s.Logger.Warn("cleanup: failed to drop pending outbox rows for deleted blob",
+			zap.String("externalID", externalID), zap.Error(err))
+	} else if n > 0 {
+		s.Logger.Info("cleanup: dropped pending outbox rows for deleted blob",
+			zap.String("externalID", externalID), zap.Int64("rows", n))
+	}
 }
 
 // StoreAndLink replaces file content for an existing document atomically.
@@ -516,9 +538,7 @@ func (s *FileService) StoreAndLinkStream(ctx context.Context, documentID uuid.UU
 			s.Logger.Warn("cleanup: failed to count references for old file",
 				zap.String("externalID", oldExternalID), zap.Error(countErr))
 		} else if count == 0 {
-			if delErr := s.Storage.Delete(oldExternalID); delErr != nil {
-				s.Logger.Warn("cleanup: failed to delete old file", zap.String("externalID", oldExternalID), zap.Error(delErr))
-			}
+			s.cleanupOrphanedBlob(ctx, oldExternalID)
 		}
 	}
 

--- a/internal/domain/service/file_service.go
+++ b/internal/domain/service/file_service.go
@@ -89,6 +89,10 @@ func (s *FileService) priorityForMime(mimeType string) int16 {
 var (
 	backupOutboxEnqueued = expvar.NewInt("file_backup_outbox_enqueued_total")
 	backupOutboxPruned   = expvar.NewInt("file_backup_outbox_pruned_total")
+	// Orphan-hygiene deletions are a third producer-side mutation of the outbox depth; count them
+	// like the other two so an operator reconciling backlog from /internal/debug/vars (enqueued −
+	// pruned − orphaned) stays accurate and a hygiene-firing spike is visible, not silent.
+	backupOutboxOrphaned = expvar.NewInt("file_backup_outbox_orphaned_total")
 )
 
 // writeCreate persists a new document — via the transactional outbox path (a backup-outbox row
@@ -407,20 +411,24 @@ func (s *FileService) DeleteDocument(ctx context.Context, documentID uuid.UUID) 
 
 	// Only delete file if no remaining documents reference it
 	if count == 0 {
-		s.cleanupOrphanedBlob(ctx, deleted.ExternalID)
+		s.cleanupOrphanedBlob(ctx, documentID, deleted.ExternalID)
 	}
 
 	return &deleted, nil
 }
 
 // cleanupOrphanedBlob removes a blob whose last referencing file row is gone (refcount→0), and —
-// when the backup producer is on — drops any still-pending backup-outbox rows for that hash:
-// they point at bytes that no longer exist, so the consumer's fetch could only ever 404
+// when the backup producer is on — drops fileID's own still-pending backup-outbox hint for that
+// hash: it points at bytes that no longer exist, so the consumer's fetch could only ever 404
 // (file-service is the master of orphans; it deleted the blob, so it removes the dead hint too).
-// Both steps are best-effort warn-only cleanup: a leftover blob is GC-able, and a leftover
-// pending row is caught by the consumer's own 404→skip backstop. The outbox cleanup runs only
-// after a successful blob delete — while the blob exists, pending rows are still backable.
-func (s *FileService) cleanupOrphanedBlob(ctx context.Context, externalID string) {
+// The outbox delete is scoped to (fileID, externalID), NOT the hash alone: under content
+// addressing a concurrent re-upload of the same content enqueues a pending row with the same
+// externalID but a different fileID, and deleting by hash would silently wipe that live
+// document's backup hint — an unrecoverable DR gap. Both steps are best-effort warn-only
+// cleanup: a leftover blob is GC-able, and a leftover pending row is caught by the consumer's
+// own 404→skip backstop. The outbox cleanup runs only after a successful blob delete — while the
+// blob exists, pending rows are still backable.
+func (s *FileService) cleanupOrphanedBlob(ctx context.Context, fileID uuid.UUID, externalID string) {
 	if err := s.Storage.Delete(externalID); err != nil {
 		s.Logger.Warn("cleanup: failed to delete orphaned file", zap.String("externalID", externalID), zap.Error(err))
 		return
@@ -428,12 +436,13 @@ func (s *FileService) cleanupOrphanedBlob(ctx context.Context, externalID string
 	if s.Outbox == nil {
 		return
 	}
-	if n, err := s.Outbox.DeletePendingByHash(ctx, externalID); err != nil {
-		s.Logger.Warn("cleanup: failed to drop pending outbox rows for deleted blob",
-			zap.String("externalID", externalID), zap.Error(err))
+	if n, err := s.Outbox.DeletePendingForFile(ctx, fileID, externalID); err != nil {
+		s.Logger.Warn("cleanup: failed to drop pending outbox row for deleted blob",
+			zap.String("fileID", fileID.String()), zap.String("externalID", externalID), zap.Error(err))
 	} else if n > 0 {
-		s.Logger.Info("cleanup: dropped pending outbox rows for deleted blob",
-			zap.String("externalID", externalID), zap.Int64("rows", n))
+		backupOutboxOrphaned.Add(n)
+		s.Logger.Info("cleanup: dropped pending outbox row for deleted blob",
+			zap.String("fileID", fileID.String()), zap.String("externalID", externalID), zap.Int64("rows", n))
 	}
 }
 
@@ -538,7 +547,7 @@ func (s *FileService) StoreAndLinkStream(ctx context.Context, documentID uuid.UU
 			s.Logger.Warn("cleanup: failed to count references for old file",
 				zap.String("externalID", oldExternalID), zap.Error(countErr))
 		} else if count == 0 {
-			s.cleanupOrphanedBlob(ctx, oldExternalID)
+			s.cleanupOrphanedBlob(ctx, documentID, oldExternalID)
 		}
 	}
 


### PR DESCRIPTION
file-service is the **master of orphans** — it owns the `file` table, the blob store, and the refcount-delete. When it removes a blob (last reference gone), any still-**pending** backup-outbox row for that hash points at bytes that no longer exist: the consumer's fetch could only ever 404.

So the cleanup that deletes the blob now also deletes those pending rows — one sqlc `DELETE`, at the two existing `count==0` cleanup sites (content-replace and document-delete), via one shared helper, flag-gated like the rest of the producer (`Outbox == nil` → no-op).

**Why this is the right home:** the backup worker stays behind the outbox wall (it reads nothing but `file_backup_outbox`); orphan knowledge lives where orphans are made. The worker's 404→skip remains purely as the race backstop (a delete landing between claim and fetch). Practical payoff: `filebackup_source_gone_total` gets a ~zero baseline, so `FileBackupSourceGoneSpike` becomes a crisp signal — any sustained rate is a real problem (misconfig, out-of-order deploy), never deletion churn.

Scope guardrails: only `pending` rows are touched (`in_progress` resolves via the consumer's own backstop; `done`/`skipped`/`dead_letter` are history), and outbox cleanup runs **only after a successful blob delete** — while the blob exists, its pending rows are still backable.

Workspace spec: `workspace#008-continuous-file-backup`. Companion to file-service#64 / file-backup-service#6 (independent of both; based on `develop`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved orphaned blob cleanup by removing still-pending backup outbox rows after the owning blob is deleted.
  * Cleanup is scoped to the specific file and content hash to avoid impacting backups from re-uploads.
  * Cleanup is best-effort and non-blocking; pending outbox pruning is skipped only when blob deletion fails.
* **Tests**
  * Added coverage for cleanup success, backup-outbox disabled behavior, zero-row deletions, and blob-deletion failure (ensuring pending rows are retained).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- pr-image-report:start -->
---
### 📦 PR image — test the current state of this PR

```bash
docker pull ghcr.io/alkem-io/file-service:pr-65
```

Current build: `ghcr.io/alkem-io/file-service:pr-65-4af2bf4` · `linux/amd64` + `linux/arm64` · index digest `sha256:34d19d6b9e11ae9135c93653aa37e7a1d29caf571d75e93c241a5aa2d8d6065d`
<!-- pr-image-report:end -->
