### PR TITLE
fix(auth): deny public reads of internal snapshot files

### DIFF
--- a/internal/adapter/inbound/http/public_handler.go
+++ b/internal/adapter/inbound/http/public_handler.go
@@ -48,6 +48,10 @@ func (h *PublicHandler) ServeDocument(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusInternalServerError, "internal error")
 		return
 	}
+	if doc.AuthorizationID == uuid.Nil {
+		writeJSONError(w, http.StatusForbidden, "insufficient privileges")
+		return
+	}
 
 	// Authorization check via h2c HTTP/2 (or NATS fallback). For anonymous
 	// callers, actorID is empty — the auth-evaluation-service treats that

--- a/internal/adapter/inbound/http/public_handler_test.go
+++ b/internal/adapter/inbound/http/public_handler_test.go
@@ -142,13 +142,14 @@ func (m *mockAuth) CheckPrivilege(_ context.Context, actorID, privilege, authPol
 }
 
 type mockStorage struct {
-	data       []byte
-	err        error
-	saveErr    error
-	saved      []byte // captures the last Save/stage payload (replace-path rejection tests)
-	stages     []*httpMockStage
-	streamBody io.ReadCloser // if set, ReadStream returns this (to inject a mid-stream read failure)
-	streamSize int64         // Content-Length ReadStream reports when streamBody is set
+	data            []byte
+	err             error
+	saveErr         error
+	saved           []byte // captures the last Save/stage payload (replace-path rejection tests)
+	stages          []*httpMockStage
+	readStreamCalls int
+	streamBody      io.ReadCloser // if set, ReadStream returns this (to inject a mid-stream read failure)
+	streamSize      int64         // Content-Length ReadStream reports when streamBody is set
 	// Per-blob data for batch tests; nil keeps the existing flat mock behavior.
 	blobsByExternalID map[string][]byte
 }
@@ -204,6 +205,7 @@ func (m *mockStorage) Read(externalID string) ([]byte, error) {
 // error to drive the handler's 400/404/500 mapping), else m.data is served over a
 // bytes reader.
 func (m *mockStorage) ReadStream(externalID string) (io.ReadCloser, int64, error) {
+	m.readStreamCalls++
 	if m.blobsByExternalID != nil {
 		if b, ok := m.blobsByExternalID[externalID]; ok {
 			return io.NopCloser(bytes.NewReader(b)), int64(len(b)), nil
@@ -294,6 +296,41 @@ func TestPublicHandler_Unauthorized(t *testing.T) {
 
 	if rr.Code != http.StatusForbidden {
 		t.Fatalf("status = %d, want 403", rr.Code)
+	}
+}
+
+func TestPublicHandler_NullAuthorizationDeniedBeforeAuthOrStorage(t *testing.T) {
+	docID := uuid.New()
+	auth := &mockAuth{result: model.AuthResult{Allowed: true}}
+	storage := &mockStorage{data: []byte("internal snapshot")}
+	h := &PublicHandler{
+		Repo: &mockDocRepo{doc: model.Document{
+			ID:              docID,
+			ExternalID:      "snapshot-hash",
+			AuthorizationID: uuid.Nil,
+		}},
+		Auth:    auth,
+		Storage: storage,
+		MaxAge:  86400,
+		Logger:  zap.NewNop(),
+	}
+
+	r := chi.NewRouter()
+	r.Get("/rest/storage/file/{id}", h.ServeDocument)
+
+	req := httptest.NewRequest(http.MethodGet, "/rest/storage/file/"+docID.String(), nil)
+	req = req.WithContext(context.WithValue(req.Context(), ctxKeyActorID, "actor-1"))
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", rr.Code)
+	}
+	if auth.calls != 0 {
+		t.Fatalf("auth-eval called %d times, want 0", auth.calls)
+	}
+	if storage.readStreamCalls != 0 {
+		t.Fatalf("storage read called %d times, want 0", storage.readStreamCalls)
 	}
 }
 


### PR DESCRIPTION
## Source

Free-text bug, no board story.

## Root cause

Internal collaboration snapshots intentionally persist with a SQL NULL `authorizationId`. The public file handler converted that missing policy to the zero UUID and delegated the decision to auth evaluation, so denial depended indirectly on no zero-ID policy ever being allowed.

## Fix

Fail closed in the public delivery handler when the stored document has `uuid.Nil` authorization, returning 403 before auth evaluation or blob storage. Internal file endpoints are unchanged.

## Regression test

`TestPublicHandler_NullAuthorizationDeniedBeforeAuthOrStorage` uses the real public route with a permissive auth mock and snapshot bytes in storage. It is RED without the guard (200 with the bytes served) and now proves 403 with zero auth calls and zero storage reads.

## Gates

- `make test`
- `make lint`
- `make build`
- `make test-vips`
- `make sqlc-generate` (no generated diff)
- `make openapi` (no generated diff)
- `git diff --check`

No production comments were added or changed.

<!-- pr-image-report:start -->
---
### 📦 PR image — test the current state of this PR

```bash
docker pull ghcr.io/alkem-io/file-service:pr-81
```

Current build: `ghcr.io/alkem-io/file-service:pr-81-2be9685` · `linux/amd64` + `linux/arm64` · index digest `sha256:09b283b8b3388a494462b72169367b15dd734cf2780c20867881b0cf2fd4b63a`
<!-- pr-image-report:end -->
